### PR TITLE
Improve types of Parser.[rules,priorities]

### DIFF
--- a/src/parsers/blocks.jl
+++ b/src/parsers/blocks.jl
@@ -47,9 +47,9 @@ mutable struct Parser <: AbstractParser
     refmap::Dict{String, Tuple{String, String}}
     last_line_length::Int
     inline_parser::InlineParser
-    rules::Vector
+    rules::Vector{Any}
     modifiers::Vector{Function}
-    priorities::Dict{Function, Float64}
+    priorities::IdDict{Function, Float64}
 
     function Parser()
         parser = new()
@@ -75,7 +75,7 @@ mutable struct Parser <: AbstractParser
         parser.inline_parser = InlineParser()
         parser.rules = []
         parser.modifiers = Function[]
-        parser.priorities = Dict()
+        parser.priorities = IdDict{Function,Float64}()
 
         # Enable the standard CommonMark rule set.
         enable!(parser, COMMONMARK_BLOCK_RULES)


### PR DESCRIPTION
This makes `rules` a concrete type, allowing things like
`length(rules)` to become inferrable. Of course the elements are
still not inferrable, but just knowing the container type gets rid of
quite a few inference triggers from running FranklinParser's tests.

This also changes `priorities` to be an `IdDict` rather than a `Dict`.
An `IdDict` is a better choice when each key is of a different type,
because it uses a different strategy for hashing and heavily
uses `@nospecialize`.

These changes shave about 0.8s off the time to run your tests.

CC @tlienart