### PR TITLE
Add test for interpolating markdown strings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonMark"
 uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
 authors = ["Michael Hatherly"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -56,4 +56,11 @@ end
     @test latex(ast) == "1 2 2 3\\par\n"
     @test markdown(ast) == "\$(value) \$(value + 1) \$(value += 1) \$(value += 1)\n"
     @test term(ast) == " \e[33m1\e[39m \e[33m2\e[39m \e[33m2\e[39m \e[33m3\e[39m\n"
+
+    # Current behavior: interpolated strings are not markdown-interpreted
+    ast = cm"""*expressions* $("**test**")"""
+    @test html(ast) == "<p><em>expressions</em> <span class=\"julia-value\">**test**</span></p>\n"
+    @test latex(ast) == "\\textit{expressions} **test**\\par\n"
+    @test markdown(ast) == "*expressions* \$(**test**)\n"
+    @test term(ast) == " \e[3mexpressions\e[23m \e[33m**test**\e[39m\n"
 end


### PR DESCRIPTION
@MichaelHatherly Looks like you were far faster than I at building out this new feature. I've been using this branch in a personal project and couldn't find a glitch so far. :) Reviewed the tests you have written, doesn't look like there are any obvious edge cases neglected as long as we keep away from the 'dollar math debacle', with the exception of the question: if an interpolated variable returns a string, do we then parse it for potential markdown syntax? Personally don't have a strong opinion, but I've encoded the status quo in a test within this PR.