### PR TITLE
Include `tex` class for HTML output to support rendering in Pluto.

### DIFF
--- a/src/extensions/math.jl
+++ b/src/extensions/math.jl
@@ -107,7 +107,7 @@ inline_rule(::DollarMathRule) = Rule(parse_inline_dollar_math, 0, "\$")
 #
 
 function write_html(::Math, rend, node, enter)
-    tag(rend, "span", attributes(rend, node, ["class" => "math"]))
+    tag(rend, "span", attributes(rend, node, ["class" => "math tex"]))
     print(rend.buffer, "\\(", node.literal, "\\)")
     tag(rend, "/span")
 end
@@ -133,7 +133,7 @@ function write_markdown(::Math, w, node, ent)
 end
 
 function write_html(::DisplayMath, rend, node, enter)
-    tag(rend, "div", attributes(rend, node, ["class" => "display-math"]))
+    tag(rend, "div", attributes(rend, node, ["class" => "display-math tex"]))
     print(rend.buffer, "\\[", node.literal, "\\]")
     tag(rend, "/div")
 end

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -45,7 +45,7 @@ end
 
     value = :interpolation
     ast = cm"'some' ``math`` $value $(value)"custom_parser
-    @test html(ast) == "<p>'some' <span class=\"math\">\\(math\\)</span> <span class=\"julia-value\">interpolation</span> <span class=\"julia-value\">interpolation</span></p>\n"
+    @test html(ast) == "<p>'some' <span class=\"math tex\">\\(math\\)</span> <span class=\"julia-value\">interpolation</span> <span class=\"julia-value\">interpolation</span></p>\n"
     @test latex(ast) == "'some' \\(math\\) interpolation interpolation\\par\n"
     @test markdown(ast) == "'some' ``math`` \$(value) \$(value)\n"
     @test term(ast) == " 'some' \e[35mmath\e[39m \e[33minterpolation\e[39m \e[33minterpolation\e[39m\n"

--- a/test/extensions/math.jl
+++ b/test/extensions/math.jl
@@ -6,7 +6,7 @@
     text = "Some ``math``."
     ast = p(text)
 
-    @test html(ast) == "<p>Some <span class=\"math\">\\(math\\)</span>.</p>\n"
+    @test html(ast) == "<p>Some <span class=\"math tex\">\\(math\\)</span>.</p>\n"
     @test latex(ast) == "Some \\(math\\).\\par\n"
     @test term(ast) == " Some \e[35mmath\e[39m.\n"
     @test markdown(ast) == "Some ``math``.\n"
@@ -18,7 +18,7 @@
     text = "```math\nmath\n```"
     ast = p(text)
 
-    @test html(ast) == "<div class=\"display-math\">\\[math\\]</div>"
+    @test html(ast) == "<div class=\"display-math tex\">\\[math\\]</div>"
     @test latex(ast) == "\\begin{equation*}\nmath\n\\end{equation*}\n"
     @test term(ast) == "   \e[35m│\e[39m \e[90mmath\e[39m\n"
     @test markdown(ast) == "```math\nmath\n```\n"
@@ -27,7 +27,7 @@
     text = "Some ``math``{key='value'}."
     ast = p(text)
 
-    @test html(ast) == "<p>Some <span class=\"math\" key=\"value\">\\(math\\)</span>.</p>\n"
+    @test html(ast) == "<p>Some <span class=\"math tex\" key=\"value\">\\(math\\)</span>.</p>\n"
 
     text =
     """
@@ -38,7 +38,7 @@
     """
     ast = p(text)
 
-    @test html(ast) == "<div class=\"display-math\" id=\"id\">\\[math\\]</div>"
+    @test html(ast) == "<div class=\"display-math tex\" id=\"id\">\\[math\\]</div>"
     @test latex(ast) == "\\protect\\hypertarget{id}{}\\begin{equation*}\nmath\n\\end{equation*}\n"
 
     # Dollar math
@@ -46,14 +46,14 @@
 
     text = raw"Some $math$."
     ast = p(text)
-    @test html(ast) == "<p>Some <span class=\"math\">\\(math\\)</span>.</p>\n"
+    @test html(ast) == "<p>Some <span class=\"math tex\">\\(math\\)</span>.</p>\n"
     @test latex(ast) == "Some \\(math\\).\\par\n"
     @test markdown(ast) == "Some ``math``.\n"
     @test term(ast) == " Some \e[35mmath\e[39m.\n"
 
     text = raw"$$display math$$"
     ast = p(text)
-    @test html(ast) == "<div class=\"display-math\">\\[display math\\]</div>"
+    @test html(ast) == "<div class=\"display-math tex\">\\[display math\\]</div>"
     @test latex(ast) == "\\begin{equation*}\ndisplay math\n\\end{equation*}\n"
     @test markdown(ast) == "```math\ndisplay math\n```\n"
     @test term(ast) == "   \e[35m│\e[39m \e[90mdisplay math\e[39m\n"


### PR DESCRIPTION
Turns out adding `tex` was all that's needed as far as I can tell. cc @disberd thanks for reporting this last week, if you've got a moment to confirm the fix that would be great.