### PR TITLE
Avoid mutating the parsed AST in `@cm_str`.

### DIFF
--- a/src/ast.jl
+++ b/src/ast.jl
@@ -40,6 +40,39 @@ mutable struct Node
     end
 end
 
+function copy_tree(func::Function, root::Node)
+    lookup = Dict{Node,Node}()
+    for (old, enter) in root
+        if enter
+            lookup[old] = Node()
+        end
+    end
+    for (old, enter) in root
+        if enter
+            new = lookup[old]
+
+            # Custom copying of the node payload.
+            new.t = func(old.t)
+
+            new.parent = get(lookup, old.parent, NULL_NODE)
+            new.first_child = get(lookup, old.first_child, NULL_NODE)
+            new.last_child = get(lookup, old.last_child, NULL_NODE)
+            new.prv = get(lookup, old.prv, NULL_NODE)
+            new.nxt = get(lookup, old.nxt, NULL_NODE)
+
+            new.sourcepos = old.sourcepos
+            new.last_line_blank = old.last_line_blank
+            new.last_line_checked = old.last_line_checked
+            new.is_open = old.is_open
+            new.literal = old.literal
+
+            new.meta = copy(old.meta)
+        end
+    end
+    return lookup[root]
+end
+copy_tree(root::Node) = copy_tree(identity, root)
+
 const NULL_NODE = Node()
 isnull(node::Node) = node === NULL_NODE
 

--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -8,8 +8,8 @@
 # macro expansion.
 struct JuliaValue <: AbstractInline
     ex
-    ref::Ref{Any}
-    JuliaValue(ex) = new(ex, Ref{Any}(nothing))
+    ref
+    JuliaValue(ex, value = nothing) = new(ex, value)
 end
 
 # This rule should only be used from the exported `@cm_str` macro and not
@@ -111,10 +111,11 @@ macro cm_str(str, name = "jmd")
 end
 
 function _interp!(ast::Node, refs::Vector, values::Vector)
-    for (jv, value) in zip(refs, values)
-        jv.ref[] = value
-    end
-    return ast
+    # Copy the parsed AST and replace any interpolations with their values.
+    lookup = Dict{JuliaValue,Any}(ref => value for (ref, value) in zip(refs, values))
+    replace(t::JuliaValue) = JuliaValue(t.ex, lookup[t])
+    replace(@nospecialize(other)) = other
+    return copy_tree(replace, ast)
 end
 
 function _init_parser(mod::Module, name::AbstractString)::Parser
@@ -156,12 +157,12 @@ end
 
 function write_html(jv::JuliaValue, rend, node, enter)
     tag(rend, "span", attributes(rend, node, ["class" => "julia-value"]))
-    print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref[]))
+    print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref))
     tag(rend, "/span")
 end
 
 function write_latex(jv::JuliaValue, rend, node, enter)
-    print(rend.buffer, sprint(_showas, MIME("text/latex"), jv.ref[]))
+    print(rend.buffer, sprint(_showas, MIME("text/latex"), jv.ref))
 end
 
 _showas(io::IO, m::MIME, obj) = showable(m, obj) ? show(io, m, obj) : print(io, obj)
@@ -169,7 +170,7 @@ _showas(io::IO, m::MIME, obj) = showable(m, obj) ? show(io, m, obj) : print(io, 
 function write_term(jv::JuliaValue, rend, node, enter)
     style = crayon"yellow"
     push_inline!(rend, style)
-    print_literal(rend, style, sprint(print, jv.ref[]), inv(style))
+    print_literal(rend, style, sprint(print, jv.ref), inv(style))
     pop_inline!(rend)
 end
 

--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -165,6 +165,12 @@ function write_latex(jv::JuliaValue, rend, node, enter)
     print(rend.buffer, sprint(_showas, MIME("text/latex"), jv.ref))
 end
 
+function _showas(io::IO, m::MIME, collection::Union{Tuple,AbstractArray,Base.Generator})
+    for each in collection
+        _showas(io, m, each)
+        print(io, " ")
+    end
+end
 _showas(io::IO, m::MIME, obj) = showable(m, obj) ? show(io, m, obj) : print(io, obj)
 
 function write_term(jv::JuliaValue, rend, node, enter)

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -64,4 +64,9 @@ end
     @test markdown(ast) == "*expressions* \$(**test**)\n"
     @test term(ast) == " \e[3mexpressions\e[23m \e[33m**test**\e[39m\n"
 
+    # Interpolated values are not linked to their macroexpansion origin.
+    asts = [cm"Value = **$(each)**" for each in 1:3]
+    @test html(asts[1]) == "<p>Value = <strong><span class=\"julia-value\">1</span></strong></p>\n"
+    @test html(asts[2]) == "<p>Value = <strong><span class=\"julia-value\">2</span></strong></p>\n"
+    @test html(asts[3]) == "<p>Value = <strong><span class=\"julia-value\">3</span></strong></p>\n"
 end

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -69,4 +69,8 @@ end
     @test html(asts[1]) == "<p>Value = <strong><span class=\"julia-value\">1</span></strong></p>\n"
     @test html(asts[2]) == "<p>Value = <strong><span class=\"julia-value\">2</span></strong></p>\n"
     @test html(asts[3]) == "<p>Value = <strong><span class=\"julia-value\">3</span></strong></p>\n"
+
+    # Interpolating collections.
+    worlds = [HTML("<div>world $i</div>") for i in 1:3]
+    @test html(cm"Hello $(worlds)") == "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
 end

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -73,4 +73,10 @@ end
     # Interpolating collections.
     worlds = [HTML("<div>world $i</div>") for i in 1:3]
     @test html(cm"Hello $(worlds)") == "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
+
+    worlds = (HTML("<div>world $i</div>") for i in 1:3)
+    @test html(cm"Hello $(worlds)") == "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
+
+    worlds = Tuple(HTML("<div>world $i</div>") for i in 1:3)
+    @test html(cm"Hello $(worlds)") == "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
 end


### PR DESCRIPTION
Fixes #29. Copy the AST parsed during macroexpansion. cc @fonsp.