### PR TITLE
Allow `_` in HTML tag name

### DIFF
--- a/src/utils/common.jl
+++ b/src/utils/common.jl
@@ -1,7 +1,7 @@
 # TODO: entity regex #[0-9]{1,8} not technically correct, should be #[0-9]{1,7}
 # but this seems to be required for passing one of the sample cases from cmark.
 const ENTITY                = "&(?:#x[a-f0-9]{1,6}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});"
-const TAGNAME               = "[A-Za-z][A-Za-z0-9-]*"
+const TAGNAME               = "[A-Za-z][A-Za-z0-9_-]*"
 const ATTRIBUTENAME         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
 const UNQUOTEDVALUE         = "[^\"'=<>`\\x00-\\x20]+"
 const SINGLEQUOTEDVALUE     = "'[^']*'"


### PR DESCRIPTION
Not super important, but I found that `_` is a legal character in HTML tags

<img width="1202" alt="Schermafbeelding 2021-12-22 om 11 04 14" src="https://user-images.githubusercontent.com/6933510/147074994-8215eb98-e34d-41de-982a-8571de579e0e.png">
