### PR TITLE
RFC: implement invalid reference link callbacks

### DIFF
--- a/src/parsers/blocks.jl
+++ b/src/parsers/blocks.jl
@@ -44,7 +44,7 @@ mutable struct Parser <: AbstractParser
     partially_consumed_tab::Bool
     all_closed::Bool
     last_matched_container::Node
-    refmap::Dict{String, Tuple{String, String}}
+    refmap::RefMap
     last_line_length::Int
     inline_parser::InlineParser
     rules::Vector{Any}
@@ -70,7 +70,7 @@ mutable struct Parser <: AbstractParser
         parser.partially_consumed_tab = false
         parser.all_closed = true
         parser.last_matched_container = parser.doc
-        parser.refmap = Dict()
+        parser.refmap = RefMap()
         parser.last_line_length = 0
         parser.inline_parser = InlineParser()
         parser.rules = []
@@ -427,7 +427,7 @@ function parse(parser::Parser, my_input::IO; kws...)
     parser.doc = Node(Document(), ((1, 1), (0, 0)))
     isempty(kws) || (merge!(parser.doc.meta, Dict(string(k) => v for (k, v) in kws)))
     parser.tip = parser.doc
-    parser.refmap = Dict{String, Tuple{String, String}}()
+    empty!(parser.refmap.cache)
     parser.line_number = 0
     parser.last_line_length = 0
     parser.pos = 1

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -155,13 +155,12 @@ function parse_close_bracket(parser::InlineParser, block::Node)
             # If shortcut reference link, rewind before spaces we skipped.
             seek(parser, savepos)
         end
-        if !isempty(reflabel)
-            # Lookup rawlabel in refmap.
-            link = get(parser.refmap, normalize_reference(reflabel), nothing)
-            if link !== nothing
-                dest, title = link
-                matched = true
-            end
+        # Lookup rawlabel in refmap. Note: it is possible for the refmap callbacks to
+        # return a meaningful link for empty reflabels too.
+        link = get(parser.refmap, normalize_reference(reflabel), nothing)
+        if link !== nothing
+            dest, title = link
+            matched = true
         end
     end
     if matched
@@ -211,7 +210,7 @@ end
 
 remove_bracket!(p::InlineParser) = p.brackets = p.brackets.previous
 
-function parse_reference(parser::InlineParser, s::AbstractString, refmap::Dict)
+function parse_reference(parser::InlineParser, s::AbstractString, refmap::RefMap)
     parser.buf = s
     seek(parser, 1)
     startpos = position(parser)

--- a/test/parser_hooks.jl
+++ b/test/parser_hooks.jl
@@ -1,0 +1,56 @@
+@testset "Parser Hooks" begin
+    # Without callbacks, an invalid reference link gets interpreted as a string
+    p = Parser()
+    n = p("[Foo][foo], [Bar][bar]\n\n[foo]: bar")
+    @test n.first_child.first_child.t isa CommonMark.Link
+    @test n.first_child.first_child.t.destination == "bar"
+    @test n.first_child.first_child.nxt.nxt.t isa CommonMark.Text
+    @test n.first_child.first_child.nxt.nxt.literal == "["
+
+    # This tests we provide a proper fallback link for 'bar'
+    p = Parser()
+    push!(p.refmap.callbacks, s -> begin
+        @test s == "bar"
+        return ("url", "title")
+    end)
+    n = p("[Foo][foo], [Bar][bar]\n\n[foo]: bar")
+    @test n.first_child.first_child.t isa CommonMark.Link
+    @test n.first_child.first_child.t.destination == "bar"
+    @test n.first_child.first_child.nxt.nxt.t isa CommonMark.Link
+    @test n.first_child.first_child.nxt.nxt.t.destination == "url"
+    @test n.first_child.first_child.nxt.nxt.t.title == "title"
+    # Make sure the cache gets emptied between runs, and we also check that if
+    # callback returns nothing, it gets parsed as a string, like normally.
+    empty!(p.refmap.callbacks)
+    n_times_called = 0
+    push!(p.refmap.callbacks, s -> begin
+        n_times_called += 1
+        @test s == "bar"
+        return nothing
+    end)
+    n = p("[Foo][foo], [Qux][bar]\n\n[foo]: barx")
+    # If the parsin fails the callback gets called twice somehow..
+    @test_broken n_times_called == 1
+    @test n.first_child.first_child.t isa CommonMark.Link
+    @test n.first_child.first_child.t.destination == "barx"
+    @test n.first_child.first_child.nxt.nxt.t isa CommonMark.Text
+    @test n.first_child.first_child.nxt.nxt.literal == "["
+
+    # Multiple callbacks
+    p = Parser()
+    push!(p.refmap.callbacks, s -> begin
+        @test s ∈ ["foo", "bar"]
+        (s == "foo") ? ("url", "title") : nothing
+    end)
+    push!(p.refmap.callbacks, s -> begin
+        @test s == "bar"
+        return ("url2", "title2")
+    end)
+    n = p("[Foo][foo], [Bar][bar]")
+    @test n.first_child.first_child.t isa CommonMark.Link
+    @test n.first_child.first_child.t.destination == "url"
+    @test n.first_child.first_child.t.title == "title"
+    @test n.first_child.first_child.nxt.nxt.t isa CommonMark.Link
+    @test n.first_child.first_child.nxt.nxt.t.destination == "url2"
+    @test n.first_child.first_child.nxt.nxt.t.title == "title2"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ using CommonMark, Test, JSON, Pkg.TOML, Mustache, YAML
     include("spec.jl")
     include("ast.jl")
     include("parsing.jl")
+    include("parser_hooks.jl")
     include("writers.jl")
     include("extensions.jl")
     include("templates.jl")


### PR DESCRIPTION
This is one possible implementation of user-provided callbacks for invalid reference links (https://github.com/MichaelHatherly/CommonMark.jl/issues/40#issuecomment-1085406385). For now, I decided to go with a `Parser`-level option. But rather than implementing a new field, I decided to integrate this with the existing `.refmap`, to minimize the code changes. But this is more of a PoC and I think the API should be improved (e.g. adding/removing callbacks means interacting with an internal field, which I think should avoided).

However, what I really wanted to do was to implement this as an option to `LinkRule` (and `ImageRule`). But I couldn't figure out how to do that without re-engineering a lot of the general code. Basically, I would imagine you can just replace the default `LinkRule` with `LinkRule(mycallback)` and then `mycallback(s)` would get called somehow.

But, when the parsing functions get called (`parse_close_bracket` in particular), it does not have access to the actual `LinkRule` object. I thought about passing it via a closure, but my impression is that these `parse_*` functions should not carry state (e.g. there will be confusion if `ImageRule` and `LinkRule` both try to add a function with different state, since they both trigger on the same character). I also thought about just looping over `p.rules` and finding the corresponding rule object, but `parse_close_bracket` does not have access to the `Parser` object (just `InlineParser`).

The next iteration was to then have a way of declaring that a `LinkRule` can "register" some sort of new hooks (I don't think the existing `*_rule` / `*_modifier` functions could be re-used for this) when you `enable!` it. But that still requires support on the `Parser` object level, so I felt it's not too different from the approach I took right now.

I do feel that doing this on the rule level would be better than on the parser level. But it feels like that would require some more general changes (e.g. expanding the call signature of the `parse_*` functions).