### PR TITLE
WIP: Use MarkdownAST representation for the AST

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,55 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.3"
+manifest_format = "2.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.3"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MarkdownAST]]
+deps = ["Markdown"]
+git-tree-sha1 = "49f6558614881bf9eabbd79080f2efd56a62b0ce"
+repo-rev = "main"
+repo-url = "https://github.com/JuliaDocs/MarkdownAST.jl.git"
+uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+version = "0.1.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "0044b23da09b5608b4ecacb4e5e6c6332f833a7e"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.3.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.URIs]]
+git-tree-sha1 = "e59ecc5a41b000fa94423a578d29290c7266fc10"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.4.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.8.6"
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]

--- a/src/CommonMark.jl
+++ b/src/CommonMark.jl
@@ -1,7 +1,9 @@
 module CommonMark
 
 import JSON, URIs
+import MarkdownAST
 
+include("markdownast.jl")
 include("utils.jl")
 include("ast.jl")
 include("parsers.jl")

--- a/src/ast.jl
+++ b/src/ast.jl
@@ -1,47 +1,7 @@
-abstract type AbstractContainer end
-abstract type AbstractBlock <: AbstractContainer end
-abstract type AbstractInline <: AbstractContainer end
-
 is_container(::AbstractContainer) = false
 
-const SourcePos = NTuple{2, NTuple{2, Int}}
-
-mutable struct Node
-    t::AbstractContainer
-    parent::Node
-    first_child::Node
-    last_child::Node
-    prv::Node
-    nxt::Node
-    sourcepos::SourcePos
-    last_line_blank::Bool
-    last_line_checked::Bool
-    is_open::Bool
-    literal::String
-    meta::Dict{String,Any}
-
-    Node() = new()
-
-    function Node(t::AbstractContainer, sourcepos=((0, 0), (0, 0)))
-        node = new()
-        node.t = t
-        node.parent = NULL_NODE
-        node.first_child = NULL_NODE
-        node.last_child = NULL_NODE
-        node.prv = NULL_NODE
-        node.nxt = NULL_NODE
-        node.sourcepos = sourcepos
-        node.last_line_blank = false
-        node.last_line_checked = false
-        node.is_open = true
-        node.literal = ""
-        node.meta = Dict{String,Any}()
-        return node
-    end
-end
-
 function copy_tree(func::Function, root::Node)
-    lookup = Dict{Node,Node}()
+    lookup = IdDict{Node,Node}()
     for (old, enter) in root
         if enter
             lookup[old] = Node()
@@ -72,9 +32,6 @@ function copy_tree(func::Function, root::Node)
     return lookup[root]
 end
 copy_tree(root::Node) = copy_tree(identity, root)
-
-const NULL_NODE = Node()
-isnull(node::Node) = node === NULL_NODE
 
 is_container(node::Node) = is_container(node.t)::Bool
 

--- a/src/markdownast.jl
+++ b/src/markdownast.jl
@@ -1,0 +1,97 @@
+const AbstractContainer = MarkdownAST.AbstractElement
+using MarkdownAST: AbstractBlock, AbstractInline
+
+# MarkdownAST.Node does not allow uninitialized fields., so we put this in .t
+# for NULL_NODE
+struct NullElement <: AbstractContainer end
+
+const SourcePos = NTuple{2, NTuple{2, Int}}
+
+mutable struct NodeMeta
+    sourcepos::SourcePos
+    last_line_blank::Bool
+    last_line_checked::Bool
+    is_open::Bool
+    literal::String
+    meta::Dict{String,Any}
+
+    function NodeMeta(sourcepos=((0, 0), (0, 0)))
+        m = new()
+        m.sourcepos = sourcepos
+        m.last_line_blank = false
+        m.last_line_checked = false
+        m.is_open = true
+        m.literal = ""
+        m.meta = Dict{String,Any}()
+        return m
+    end
+end
+
+const Node = MarkdownAST.Node{NodeMeta}
+Node(t::AbstractContainer, sourcepos::SourcePos) = Node(t, NodeMeta(sourcepos))
+Node(t::AbstractContainer) = Node(t, NodeMeta())
+Node() = Node(NullElement())
+
+const NULL_NODE = Node()
+isnull(node::Node) = (node.element isa NullElement)
+
+function Base.getproperty(node::Node, name::Symbol)
+    if name === :parent
+        n = getfield(node, :parent)
+        isnothing(n) ? NULL_NODE : n
+    elseif name === :first_child
+        n = getfield(node, :first_child)
+        isnothing(n) ? NULL_NODE : n
+    elseif name === :last_child
+        n = getfield(node, :last_child)
+        isnothing(n) ? NULL_NODE : n
+    elseif name === :prv
+        n = getfield(node, :prv)
+        isnothing(n) ? NULL_NODE : n
+    elseif name === :nxt
+        n = getfield(node, :nxt)
+        isnothing(n) ? NULL_NODE : n
+    elseif name === :sourcepos
+        getfield(node, :meta).sourcepos
+    elseif name === :last_line_blank
+        getfield(node, :meta).last_line_blank
+    elseif name === :last_line_checked
+        getfield(node, :meta).last_line_checked
+    elseif name === :is_open
+        getfield(node, :meta).is_open
+    elseif name === :literal
+        getfield(node, :meta).literal
+    elseif name === :meta
+        getfield(node, :meta).meta
+    else
+        invoke(getproperty, Tuple{MarkdownAST.Node, Symbol}, node, name)
+    end
+end
+
+function Base.setproperty!(node::Node, name::Symbol, x)
+    if name === :parent
+        setfield!(node, :parent, (x === NULL_NODE) ? nothing : x)
+    elseif name === :first_child
+        setfield!(node, :first_child, (x === NULL_NODE) ? nothing : x)
+    elseif name === :last_child
+        setfield!(node, :last_child, (x === NULL_NODE) ? nothing : x)
+    elseif name === :prv
+        setfield!(node, :prv, (x === NULL_NODE) ? nothing : x)
+    elseif name === :nxt
+        setfield!(node, :nxt, (x === NULL_NODE) ? nothing : x)
+    elseif name === :sourcepos
+        getfield(node, :meta).sourcepos = x
+    elseif name === :last_line_blank
+        getfield(node, :meta).last_line_blank = x
+    elseif name === :last_line_checked
+        getfield(node, :meta).last_line_checked = x
+    elseif name === :is_open
+        getfield(node, :meta).is_open = x
+    elseif name === :literal
+        getfield(node, :meta).literal = x
+    elseif name === :meta
+        getfield(node, :meta).meta = x
+    else
+        invoke(setproperty!, Tuple{MarkdownAST.Node, Symbol, Any}, node, name, x)
+    end
+end


### PR DESCRIPTION
This is just a proof of concept, but shows how we can use the `Node` type from MarkdownAST, by just overloading the properties of the fully qualified type.

```
julia> using CommonMark, MarkdownAST

julia> p = Parser()
Parser(Node(CommonMark.Document))

julia> md = p("Foo *bar* [baz](x \"y\").")
 Foo bar baz.

# Use the AST printing method from MarkdownAST:
julia> invoke(show, Tuple{IO, MarkdownAST.Node}, stdout, md)
@ast CommonMark.NodeMeta CommonMark.Document() do
  CommonMark.Paragraph() do
    CommonMark.Text()
    CommonMark.Emph() do
      CommonMark.Text()
    end
    CommonMark.Text()
    CommonMark.Link("x", "y") do
      CommonMark.Text()
    end
    CommonMark.Text()
  end
end
```

I am actually a little surprised that this required literally no code changes. The next step I can take is to replace most of the container/element types, which should also be trivial, since I don't think I changed their fields (`Text` is an exception).