### PR TITLE
Fix inconsistent interpolation evaluation due to Julia bug

### DIFF
--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -107,7 +107,12 @@ macro cm_str(str, name = "jmd")
     parser = _init_parser(__module__, name)
     enable!(parser, ji)
     ast = parser(str)
-    return :(_interp!($ast, $(ji.captured), $(Expr(:vect, [esc(v.ex) for v in ji.captured]...))))
+    expr = Expr(:block, :(values = []))
+    for v in ji.captured
+        push!(expr.args, :(let x = $(esc(v.ex)); push!(values, x); end))
+    end
+    push!(expr.args, :(_interp!($ast, $(ji.captured), values)))
+    return expr
 end
 
 function _interp!(ast::Node, refs::Vector, values::Vector)

--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -107,6 +107,10 @@ macro cm_str(str, name = "jmd")
     parser = _init_parser(__module__, name)
     enable!(parser, ji)
     ast = parser(str)
+    # We construct an expression that first, one-by-one and in order, evaluates each
+    # of the interpolated expressions that appeared in the string, adds them to a
+    # list, and finally calls _interp! on it to update the AST with the evaluated
+    # values.
     expr = Expr(:block, :(values = []))
     for v in ji.captured
         push!(expr.args, :(let x = $(esc(v.ex)); push!(values, x); end))

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -64,7 +64,7 @@ end
         global value_global
         value_global = 1
         ast = cm"$(value_global) $(value_global + 1) $(value_global += 1) $(value_global += 1)"
-        @test_broken latex(ast) == "1 2 2 3\\par\n"
+        @test latex(ast) == "1 2 2 3\\par\n"
     end
 
     # Interpolated strings are not markdown-interpreted

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -57,6 +57,16 @@ end
     @test markdown(ast) == "\$(value) \$(value + 1) \$(value += 1) \$(value += 1)\n"
     @test term(ast) == " \e[33m1\e[39m \e[33m2\e[39m \e[33m2\e[39m \e[33m3\e[39m\n"
 
+    # A case that can fail if the @cm_str macro relies on evaluating the passed expressions in argument
+    # lists (like the constructor of a vector).
+    # https://github.com/JuliaLang/julia/issues/46251
+    let
+        global value_global
+        value_global = 1
+        ast = cm"$(value_global) $(value_global + 1) $(value_global += 1) $(value_global += 1)"
+        @test_broken latex(ast) == "1 2 2 3\\par\n"
+    end
+
     # Interpolated strings are not markdown-interpreted
     ast = cm"""*expressions* $("**test**")"""
     @test html(ast) == "<p><em>expressions</em> <span class=\"julia-value\">**test**</span></p>\n"

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -89,4 +89,15 @@ end
 
     worlds = Tuple(HTML("<div>world $i</div>") for i in 1:3)
     @test html(cm"Hello $(worlds)") == "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
+
+    # Make sure that the evaluation of values happens at runtime.
+    f(x) = cm"if x = $(x), then x² = $(x^2)"
+    let ast = f(2)
+        @test markdown(ast) == "if x = \$(x), then x² = \$(x ^ 2)\n"
+        @test term(ast) == " if x = \e[33m2\e[39m, then x² = \e[33m4\e[39m\n"
+    end
+    let ast = f(-3)
+        @test markdown(ast) == "if x = \$(x), then x² = \$(x ^ 2)\n"
+        @test term(ast) == " if x = \e[33m-3\e[39m, then x² = \e[33m9\e[39m\n"
+    end
 end


### PR DESCRIPTION
I noticed that the tests that parse this string

```julia
value = 1
ast = cm"$(value) $(value + 1) $(value += 1) $(value += 1)"
```

intermittently fail. It turns out that assignments in argument lists (which `cm""` depends on, when it constructs the vector of values) are problematic: https://github.com/JuliaLang/julia/issues/46251

This changes the `cm""` macro such that the generated code evaluates the values one-by-one and pushes them into a vector that later gets passed to `_interp!`, rather than constructing the vector in one go with a `[ ... ]` expression. This should make sure that values are evaluated in a deterministic order.

I split the commits to see if the MWE test also fails on CI systematically, but I think the PR should be squash-merged.