### PR TITLE
Fix interpolation with repeating, mutating names

### DIFF
--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -4,19 +4,23 @@
 # from within the `@cm_str` macro otherwise the expressions won't have "time"
 # to actually evaluate.
 
+# Captures an interpolated Julia expression and its position in the string
+struct JuliaExpression <: AbstractInline
+    pos::Int
+    ex
+end
 # Captures an expression and the future value associated with it after
 # macro expansion.
 struct JuliaValue <: AbstractInline
     ex
     ref
-    JuliaValue(ex, value = nothing) = new(ex, value)
 end
 
 # This rule should only be used from the exported `@cm_str` macro and not
 # `enabled!` directly by users on a `Parser` object.
 struct JuliaInterpolationRule
-    captured::Vector{JuliaValue}
-    JuliaInterpolationRule() = new(JuliaValue[])
+    captured::Vector{JuliaExpression}
+    JuliaInterpolationRule() = new(JuliaExpression[])
 end
 
 const reInterpHere = r"^\$"
@@ -35,7 +39,7 @@ inline_rule(ji::JuliaInterpolationRule) = Rule(1, "\$") do p, node
             return false
         else
             seek(p, after_expr - 1) # Offset Meta.parse end position.
-            ref = JuliaValue(ex)
+            ref = JuliaExpression(length(ji.captured) + 1, ex)
             push!(ji.captured, ref)
             append_child(node, Node(ref))
             return true
@@ -121,8 +125,7 @@ end
 
 function _interp!(ast::Node, refs::Vector, values::Vector)
     # Copy the parsed AST and replace any interpolations with their values.
-    lookup = Dict{JuliaValue,Any}(ref => value for (ref, value) in zip(refs, values))
-    replace(t::JuliaValue) = JuliaValue(t.ex, lookup[t])
+    replace(t::JuliaExpression) = JuliaValue(t.ex, values[t.pos])
     replace(@nospecialize(other)) = other
     return copy_tree(replace, ast)
 end
@@ -164,6 +167,29 @@ end
 # Writers
 #
 
+# JuliaExpression
+
+function write_html(jv::JuliaExpression, rend, node, enter)
+    tag(rend, "span", attributes(rend, node, ["class" => "julia-expr"]))
+    print(rend.buffer, sprint(print, '$', "($(jv.ex))"))
+    tag(rend, "/span")
+end
+
+function write_latex(jv::JuliaExpression, rend, node, enter)
+    print(rend.buffer, "\\texttt{", '\\', '$', '(')
+    latex_escape(rend, string(jv.ex))
+    print(rend.buffer, ")}")
+end
+
+function write_term(jv::JuliaExpression, rend, node, enter)
+    style = crayon"yellow"
+    push_inline!(rend, style)
+    print_literal(rend, style, sprint(print, '$', "($(jv.ex))"), inv(style))
+    pop_inline!(rend)
+end
+
+# JuliaValue
+
 function write_html(jv::JuliaValue, rend, node, enter)
     tag(rend, "span", attributes(rend, node, ["class" => "julia-value"]))
     print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref))
@@ -191,4 +217,4 @@ end
 
 # Markdown output should be roundtrip-able, so printout the interpolated
 # expression rather than it's value.
-write_markdown(jv::JuliaValue, rend, node, ent) = print(rend.buffer, '$', "($(jv.ex))")
+write_markdown(jv::Union{JuliaExpression,JuliaValue}, rend, node, ent) = print(rend.buffer, '$', "($(jv.ex))")


### PR DESCRIPTION
A variable that is interpolated multiple times with updates in between will print with the final value in all positions:

```
julia> let x = 1
           function f!(); x += 1; 42; end
           cm"$(x), $(f!()), $(x)"
       end
 2, 42, 2
```

This is because `JuliaValue` is a struct and therefore the two instance of `JuliaValue(:x, nothing)` are identical. This confuses the replacement `Dict` in `_interp!`, where value from the earlier position gets overwritten.

Changing `JuliaValue` to be mutable and using `IdDict` in `_interp!` fixes this:

```
julia> let x = 1
           function f!(); x += 1; 42; end
           cm"$(x), $(f!()), $(x)"
       end
 1, 42, 2
```

A few notes:

* Strictly, `IdDict` is not necessary. However, using it makes sure it keeps working if `==` and `hash` were to become overloaded (which is what I do in MarkdownAST right now).

* An alternative solution could be to add a position counter to `JuliaValue`, which would get incremented every time the parser constructs a new `JuliaValue`.

* This only affects pure variable interpolation, since `Expr` objects are mutable, and so won't match even if they have identical content.