### PR TITLE
fix unicode breaking

### DIFF
--- a/src/parsers/blocks.jl
+++ b/src/parsers/blocks.jl
@@ -233,7 +233,8 @@ function advance_offset(parser::Parser, count::Integer, columns::Bool)
             parser.column += 1
             count -= 1
         end
-        c = get(buf, thisind(buf, parser.pos), '\0')
+        parser.pos = thisind(buf, parser.pos)
+        c = get(buf, parser.pos, '\0')
     end
 end
 

--- a/src/parsers/blocks.jl
+++ b/src/parsers/blocks.jl
@@ -228,12 +228,11 @@ function advance_offset(parser::Parser, count::Integer, columns::Bool)
             end
         else
             parser.partially_consumed_tab = false
-            parser.pos += 1
+            parser.pos = nextind(buf, parser.pos)
             # Assume ASCII; block starts are ASCII.
             parser.column += 1
             count -= 1
         end
-        parser.pos = thisind(buf, parser.pos)
         c = get(buf, parser.pos, '\0')
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,8 @@ using CommonMark, Test, JSON, Pkg.TOML, Mustache, YAML
     include("templates.jl")
     include("integration.jl")
 
+    include("unicodes.jl")
+
     # Basics: just make sure the parsing and rendering doesn't throw or hang.
     @testset "Samples" begin
         for (root, dirs, files) in walkdir(joinpath(@__DIR__, "samples"))

--- a/test/unicodes.jl
+++ b/test/unicodes.jl
@@ -1,0 +1,6 @@
+@testset "Unicodes" begin
+	p = Parser()
+	enable!(p, AdmonitionRule())
+	text = "!!! note \"Ju 的文字\"\n    Ju\n"
+	@test html(p(text)) == "<div class=\"admonition note\"><p class=\"admonition-title\">Ju 的文字</p>\n<p>Ju</p>\n</div>"
+end


### PR DESCRIPTION
This fixes the first problem in https://github.com/MichaelHatherly/CommonMark.jl/issues/52