### PR TITLE
Add convert method for MarkdownAST

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.8.7"
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 Crayons = "4"
 JSON = "0.20, 0.21"
+MarkdownAST = "0.1"
 URIs = "1.1"
 julia = "1"
 

--- a/src/CommonMark.jl
+++ b/src/CommonMark.jl
@@ -7,6 +7,7 @@ include("ast.jl")
 include("parsers.jl")
 include("writers.jl")
 include("extensions.jl")
+include("markdownast.jl")
 
 # Interface
 export Parser, enable!, disable!, html, latex, term, markdown, notebook,

--- a/src/markdownast.jl
+++ b/src/markdownast.jl
@@ -1,0 +1,90 @@
+#= These imports can be used to use this file outside of CommonMark:
+
+using CommonMark: Node, AbstractContainer, NULL_NODE,
+    Document, Paragraph, BlockQuote, ThematicBreak, HtmlBlock, DisplayMath,
+    Heading, CodeBlock, Admonition, List, Item, FootnoteDefinition,
+    LineBreak, Backslash, SoftBreak, Emph, Strong, HtmlInline, Math, FootnoteLink, Text,
+    Code, Image, Link, JuliaValue, Table, TableBody, TableCell, TableHeader, TableRow
+=#
+
+import MarkdownAST
+
+function Base.convert(::Type{MarkdownAST.Node}, node::Node)
+    mdast = _mdast_node(node)
+    let child = node.first_child
+        while child != NULL_NODE
+            mdast_child = convert(MarkdownAST.Node, child)
+            push!(mdast.children, mdast_child)
+            child = child.nxt
+        end
+    end
+    return mdast
+end
+
+_mdast_node(node::Node) = _mdast_node(node, node.t)
+
+# Fallback convert function
+_mdast_node(node::Node, ::T) where {T <: AbstractContainer} = error("'$T' container not supported in MarkdownAST")
+
+# For all singleton containers that map trivially (i.e. they have no attributes),
+# we can have a single implementation.
+const SINGLETON_CONTAINER_MAP = Dict(
+    Document => MarkdownAST.Document,
+    Paragraph => MarkdownAST.Paragraph,
+    BlockQuote => MarkdownAST.BlockQuote,
+    ThematicBreak => MarkdownAST.ThematicBreak,
+    LineBreak => MarkdownAST.LineBreak,
+    Backslash => MarkdownAST.Backslash,
+    SoftBreak => MarkdownAST.SoftBreak,
+    Emph => MarkdownAST.Emph,
+    Strong => MarkdownAST.Strong,
+    # CommonMark.Item contains a field, but it's discarded in MarkdownAST
+    Item => MarkdownAST.Item,
+    # Internal nodes for tables
+    TableBody => MarkdownAST.TableBody,
+    TableHeader => MarkdownAST.TableHeader,
+    TableRow => MarkdownAST.TableRow,
+)
+const SINGLETON_CONTAINERS = Union{keys(SINGLETON_CONTAINER_MAP)...}
+function _mdast_node(node::Node, container::SINGLETON_CONTAINERS)
+    e = SINGLETON_CONTAINER_MAP[typeof(container)]()
+    return MarkdownAST.Node(e)
+end
+
+# Some containers use the .literal field of the Node object to store the content,
+# which generally maps to MarkdownAST.T(node.literal).
+const LITERAL_CONTAINER_MAP = Dict(
+    Text => MarkdownAST.Text,
+    HtmlBlock => MarkdownAST.HTMLBlock,
+    HtmlInline => MarkdownAST.HTMLInline,
+    DisplayMath => MarkdownAST.DisplayMath,
+    Math => MarkdownAST.InlineMath,
+    Code => MarkdownAST.Code,
+)
+const LITERAL_CONTAINERS = Union{keys(LITERAL_CONTAINER_MAP)...}
+function _mdast_node(node::Node, container::LITERAL_CONTAINERS)
+    e = LITERAL_CONTAINER_MAP[typeof(container)](node.literal)
+    return MarkdownAST.Node(e)
+end
+
+# Containers that need special handling
+_mdast_node(n::Node, c::Heading) = MarkdownAST.Node(MarkdownAST.Heading(c.level))
+_mdast_node(n::Node, c::Link) = MarkdownAST.Node(MarkdownAST.Link(c.destination, c.title))
+_mdast_node(n::Node, c::Image) = MarkdownAST.Node(MarkdownAST.Image(c.destination, c.title))
+_mdast_node(n::Node, c::List) = MarkdownAST.Node(MarkdownAST.List(c.list_data.type, c.list_data.tight))
+_mdast_node(n::Node, c::CodeBlock) = MarkdownAST.Node(MarkdownAST.CodeBlock(c.info, n.literal))
+_mdast_node(n::Node, c::Admonition) = MarkdownAST.Node(MarkdownAST.Admonition(c.category, c.title))
+_mdast_node(n::Node, c::FootnoteDefinition) = MarkdownAST.Node(MarkdownAST.FootnoteDefinition(c.id))
+_mdast_node(n::Node, c::FootnoteLink) = MarkdownAST.Node(MarkdownAST.FootnoteLink(c.id))
+_mdast_node(n::Node, c::Table) = MarkdownAST.Node(MarkdownAST.Table(c.spec))
+_mdast_node(n::Node, c::TableCell) = MarkdownAST.Node(MarkdownAST.TableCell(c.align, c.header, c.column))
+_mdast_node(n::Node, c::JuliaValue) = MarkdownAST.Node(MarkdownAST.JuliaValue(c.ex, c.ref))
+
+# Unsupported containers (no MarkdownAST equivalent currently):
+#
+# Attributes, Citation, CitationBracket, FrontMatter, ReferenceList, References,
+# LaTeXBlock, LaTeXInline
+#
+# Should never appear in a CommonMark tree:
+#
+# TablePipe (internal use), TableComponent (abstract), JuliaExpression (internal use)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/markdownast.jl
+++ b/test/markdownast.jl
@@ -1,0 +1,52 @@
+import MarkdownAST
+
+@testset "MarkdownAST conversion" begin
+    cmnodes = cm"""
+    # Heading
+
+    hello *world*
+
+    ```julia
+    foo
+    ```
+
+    [foo **bar** baz](url "asdsd")
+
+    ![foo **bar** baz](url "asdsd") ![foo **bar** baz](url "asdsd")
+
+    !!! info "Info"
+
+        > asdasd
+
+    ## Footnotes
+
+    Reference[^1].
+
+    [^1]: foonote
+
+    ## Table
+
+    | 1 | 10 | 100 |
+    | - | --:|:---:|
+    | x | y  | z   |
+
+    ## Interpolation
+
+    $(1+2+3)
+    """
+    @test convert(MarkdownAST.Node, cmnodes) isa MarkdownAST.Node
+
+    SAMPLES_DIR = joinpath(@__DIR__, "samples", "cmark")
+    mdsamples = [
+        joinpath(SAMPLES_DIR, filename)
+        for filename in filter(endswith(".md"), readdir(SAMPLES_DIR))
+    ]
+    p = Parser()
+    enable!(p, CommonMark.AdmonitionRule())
+    enable!(p, CommonMark.FootnoteRule())
+    enable!(p, CommonMark.TableRule())
+    for samplefile in mdsamples
+        cmnodes = p(read(samplefile, String))
+        @test convert(MarkdownAST.Node, cmnodes) isa MarkdownAST.Node
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,4 +48,6 @@ using CommonMark, Test, JSON, Pkg.TOML, Mustache, YAML
             end
         end
     end
+
+    include("markdownast.jl")
 end


### PR DESCRIPTION
Compared to #49, a simpler (but hopefully temporary?) alternative to integrate CommonMark and MarkdownAST, by adding MarkdownAST a dependency, and providing a `convert` method from `CommonMark.Node` to `MarkdownAST.Node`.