### PR TITLE
interpolation: Pass-through IOContext to JuliaValue in HTML render

### DIFF
--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -192,7 +192,7 @@ end
 
 function write_html(jv::JuliaValue, rend, node, enter)
     tag(rend, "span", attributes(rend, node, ["class" => "julia-value"]))
-    print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref))
+    print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref; context=rend.io))
     tag(rend, "/span")
 end
 

--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -192,7 +192,7 @@ end
 
 function write_html(jv::JuliaValue, rend, node, enter)
     tag(rend, "span", attributes(rend, node, ["class" => "julia-value"]))
-    print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref; context=rend.io))
+    print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref; context=rend.buffer))
     tag(rend, "/span")
 end
 

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -122,8 +122,8 @@ end
     ast = cm"hello $(value)"
     out1 = repr(MIME"text/html"(), ast)
     out2 = repr(MIME"text/html"(), ast; context=(:secret => "🙊"))
-    @test out1 == "hello not found"
-    @test out2 == "hello 🙊"
+    @test out1 == "<p>hello <span class=\"julia-value\">not found</span></p>\n"
+    @test out2 == "<p>hello <span class=\"julia-value\">🙊</span></p>\n"
 
     # ASTs containing JuliaExpression elements
     p = Parser()

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -109,6 +109,21 @@ end
         @test markdown(ast) == "\$(x), \$(f!()), \$(x)\n"
         @test term(ast) == " \e[33m1\e[39m, \e[33m42\e[39m, \e[33m2\e[39m\n"
     end
+    
+    # IOContext passthrough
+    struct MyInterpolatedType
+    end
+    
+    function Base.show(io::IO, m::MIME"text/html", x::MyInterpolatedType)
+        write(io, get(io, :secret, "not found"))
+    end
+    
+    value = MyInterpolatedType()
+    ast = cm"hello $(value)"
+    out1 = repr(MIME"text/html"(), ast)
+    out2 = repr(MIME"text/html"(), ast; context=(:secret => "🙊"))
+    @test out1 == "hello not found"
+    @test out2 == "hello 🙊"
 
     # ASTs containing JuliaExpression elements
     p = Parser()


### PR DESCRIPTION
Hey Michael 👋

This PR makes the rendering [IOContext](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple{IO,%20Pair}) available to interpolated Julia objects. Example of using the IO context in an HTML render:

```julia
struct MyType
end

function Base.show(io::IO, m::MIME"text/html", x::MyType)
	if get(io, :limit, false) === true
		write(io, "hello")
	else
		write(io, "<marquee> hello hello hello </marquee>")
	end
end
```

This PR will fix https://github.com/fonsp/Pluto.jl/issues/1807 , because Pluto and https://github.com/JuliaPluto/AbstractPlutoDingetjes.jl use IOContext to communicate which Pluto API is available to the renderer. 

This PR is similar to https://github.com/JuliaPluto/HypertextLiteral.jl/pull/27 



Example notebook that works after this PR:

```julia
# ╔═╡ 618a92b2-a418-40c6-8d71-2129b056aa5c
begin
	import Pkg
	Pkg.activate(temp=true)
	Pkg.add([
		Pkg.PackageSpec(name="PlutoUI")
		Pkg.PackageSpec(url="https://github.com/fonsp/CommonMark.jl", rev="patch-3")
	])
end

# ╔═╡ 97d567f2-8203-11ed-1857-bdfd226ad0b7
using CommonMark

# ╔═╡ d9207c56-d2b9-48bb-b803-b94a0b685daa
using PlutoUI

# ╔═╡ 8ae91af4-8651-4bc3-bd42-98909c6ee5a7
@bind a Slider(5:9)

# ╔═╡ d4fd82c7-7eaa-4c2c-9c37-5a54986b4b49
a

# ╔═╡ 93c0ba03-ff14-492c-95f7-b454afb4fb47
bb = cm"$(@bind b Slider(5:9))"

# ╔═╡ 4331aad6-b709-464e-8ec8-0b2cea99484e
b
```