### PR TITLE
specialize occursin on regex

### DIFF
--- a/src/parsers.jl
+++ b/src/parsers.jl
@@ -53,7 +53,7 @@ Base.findnext(f::Function, p::AbstractParser) = findnext(f, String(p), position(
 Base.findprev(f::Function, p::AbstractParser) = findprev(f, String(p), position(p))
 
 Base.startswith(p::AbstractParser, prefix) = startswith(rest(p), prefix)
-Base.occursin(pat, p::AbstractParser) = occursin(pat, rest(p))
+Base.occursin(pat::Regex, p::AbstractParser) = occursin(pat, rest(p))
 
 Base.match(re::Regex, p::AbstractParser) = match(re, rest(p))
 


### PR DESCRIPTION
Before:
```julia
julia> using SnoopCompile

julia> invals = @snoopr using JuliaFormatter;

julia> tree = invalidation_trees(invals)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting joinpath(uri::URIs.URI, parts::String...) in URIs at /home/chriselrod/.julia/packages/URIs/6ecRe/src/URIs.jl:583 invalidated:
   mt_backedges: 1: signature Tuple{typeof(joinpath), Any, String} triggered MethodInstance for OpenSpecFun_jll.__init__() (0 children)
                 2: signature Tuple{typeof(joinpath), Any, String, Any} triggered MethodInstance for (::OpenSpecFun_jll.var"#make_wrapper_dict#2"{OpenSpecFun_jll.var"#parse_wrapper_platform#1"})(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(joinpath), Any, Vararg{Any}} triggered MethodInstance for expanduser(::FilePathsBase.PosixPath) (0 children)
                 4: signature Tuple{typeof(joinpath), Any, String} triggered MethodInstance for Artifacts.jointail(::Any, ::String) (0 children)

 inserting occursin(pat, p::CommonMark.AbstractParser) in CommonMark at /home/chriselrod/.julia/packages/CommonMark/f0utD/src/parsers.jl:56 invalidated:
   mt_backedges: 1: signature Tuple{typeof(occursin), String, Any} triggered MethodInstance for Base.incomplete_tag(::Expr) (2 children)

 inserting occursin(fn::Glob.FilenameMatch, s::AbstractString) in Glob at /home/chriselrod/.julia/packages/Glob/GOSfX/src/Glob.jl:48 invalidated:
   mt_backedges: 1: signature Tuple{typeof(occursin), Any, SubString{String}} triggered MethodInstance for CommonMark.incorporate_line(::CommonMark.Parser, ::String) (6 children)
   2 mt_cache

 inserting eltype(::Type{C}) where {T, C<:(ColorTypes.Colorant{T})} in ColorTypes at /home/chriselrod/.julia/packages/ColorTypes/1dGw6/src/traits.jl:126 invalidated:
   mt_backedges: 1: signature eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193 (formerly eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193) triggered MethodInstance for (Base.Pairs{Symbol})(::NamedTuple{(:maxlog, :form), _A} where _A<:Tuple{Int64, Type}, ::Tuple{Symbol, Symbol}) (122 children)
                 2: signature eltype(t::Type{<:Tuple}) in Base at tuple.jl:155 (formerly eltype(t::Type{<:Tuple}) in Base at tuple.jl:155) triggered MethodInstance for Base.nteltype(::Type{NamedTuple{(:maxlog, :form), T}}) where T<:Tuple{Int64, Type} (1 children)
                 3: signature eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146 (formerly eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146) triggered MethodInstance for (Base.Pairs{Int64})(::Tuple{Any}, ::Base.OneTo{Int64}) (95 children)
                 4: signature eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193 (formerly eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193) triggered MethodInstance for (Base.Pairs{Symbol})(::NamedTuple{(:init,), _A} where _A<:Tuple{Dict{_A, Any} where _A}, ::Tuple{Symbol}) (35 children)
                 5: signature eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146 (formerly eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146) triggered MethodInstance for Base.nteltype(::Type{NamedTuple{(:init,), T}}) where T<:Tuple{Dict{_A, Any} where _A} (1 children)
   74 mt_cache
```

After:
```julia
julia> using SnoopCompile

julia> invals = @snoopr using JuliaFormatter;

julia> tree = invalidation_trees(invals)
3-element Vector{SnoopCompile.MethodInvalidations}:
 inserting joinpath(uri::URIs.URI, parts::String...) in URIs at /home/chriselrod/.julia/packages/URIs/6ecRe/src/URIs.jl:583 invalidated:
   mt_backedges: 1: signature Tuple{typeof(joinpath), Any, String} triggered MethodInstance for OpenSpecFun_jll.__init__() (0 children)
                 2: signature Tuple{typeof(joinpath), Any, String, Any} triggered MethodInstance for (::OpenSpecFun_jll.var"#make_wrapper_dict#2"{OpenSpecFun_jll.var"#parse_wrapper_platform#1"})(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(joinpath), Any, Vararg{Any}} triggered MethodInstance for expanduser(::FilePathsBase.PosixPath) (0 children)
                 4: signature Tuple{typeof(joinpath), Any, String} triggered MethodInstance for Artifacts.jointail(::Any, ::String) (0 children)

 inserting occursin(fn::Glob.FilenameMatch, s::AbstractString) in Glob at /home/chriselrod/.julia/packages/Glob/GOSfX/src/Glob.jl:48 invalidated:
   mt_backedges: 1: signature Tuple{typeof(occursin), Any, SubString{String}} triggered MethodInstance for CommonMark.incorporate_line(::CommonMark.Parser, ::String) (6 children)
   2 mt_cache

 inserting eltype(::Type{C}) where {T, C<:(ColorTypes.Colorant{T})} in ColorTypes at /home/chriselrod/.julia/packages/ColorTypes/1dGw6/src/traits.jl:126 invalidated:
   mt_backedges: 1: signature eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193 (formerly eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193) triggered MethodInstance for (Base.Pairs{Symbol})(::NamedTuple{(:maxlog, :form), _A} where _A<:Tuple{Int64, Type}, ::Tuple{Symbol, Symbol}) (122 children)
                 2: signature eltype(t::Type{<:Tuple}) in Base at tuple.jl:155 (formerly eltype(t::Type{<:Tuple}) in Base at tuple.jl:155) triggered MethodInstance for Base.nteltype(::Type{NamedTuple{(:maxlog, :form), T}}) where T<:Tuple{Int64, Type} (1 children)
                 3: signature eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146 (formerly eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146) triggered MethodInstance for (Base.Pairs{Int64})(::Tuple{Any}, ::Base.OneTo{Int64}) (95 children)
                 4: signature eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193 (formerly eltype(::Type{T}) where T<:NamedTuple in Base at namedtuple.jl:193) triggered MethodInstance for (Base.Pairs{Symbol})(::NamedTuple{(:init,), _A} where _A<:Tuple{Dict{_A, Any} where _A}, ::Tuple{Symbol}) (35 children)
                 5: signature eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146 (formerly eltype(t::Type{<:Tuple{Vararg{E}}}) where E in Base at tuple.jl:146) triggered MethodInstance for Base.nteltype(::Type{NamedTuple{(:init,), T}}) where T<:Tuple{Dict{_A, Any} where _A} (1 children)
   74 mt_cache
```