### PR TITLE
chore: pin CI actions and migrate to JSON.jl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"
-    open-pull-requests-limit: 1

--- a/.github/workflows/ClearPreview.yml
+++ b/.github/workflows/ClearPreview.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: gh-pages
       - name: Delete preview and push

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: "1"
       - name: Install dependencies

--- a/.github/workflows/LicenseUpdater.yml
+++ b/.github/workflows/LicenseUpdater.yml
@@ -9,9 +9,9 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v3
+      - uses: FantasticFiasco/action-update-license-year@f180e962fa988db222d8f03ef4636750312d1b3d # v3.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1.25.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,15 +21,15 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
-      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1'
 
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
         with:
           cache-name: benchmark
 
@@ -53,9 +53,9 @@ jobs:
           # Try to get the latest baseline from gh-pages branch
           git fetch origin gh-pages 2>/dev/null || true
           if git show origin/gh-pages:benchmarks/results/latest.json > benchmark-output/baseline.json 2>/dev/null; then
-            echo "BASELINE_EXISTS=true" >> $GITHUB_ENV
+            echo "BASELINE_EXISTS=true" >> "$GITHUB_ENV"
           else
-            echo "BASELINE_EXISTS=false" >> $GITHUB_ENV
+            echo "BASELINE_EXISTS=false" >> "$GITHUB_ENV"
             echo "No baseline found"
           fi
 
@@ -74,14 +74,15 @@ jobs:
 
       - name: Write job summary
         run: |
-          echo "## Benchmark Results" >> $GITHUB_STEP_SUMMARY
+          echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
           if [ -f benchmark-output/comparison.md ]; then
-            cat benchmark-output/comparison.md >> $GITHUB_STEP_SUMMARY
+            cat benchmark-output/comparison.md >> "$GITHUB_STEP_SUMMARY"
           else
+            # shellcheck disable=SC2016 # $ interpolations below are Julia, not shell
             julia --project=benchmark -e '
-              import JSON3
-              results = JSON3.read(read("benchmark-output/results.json", String))
-              benchmarks = results.benchmarks
+              import JSON
+              results = JSON.parse(read("benchmark-output/results.json", String))
+              benchmarks = results["benchmarks"]
 
               format_time(ns) = ns < 1000 ? "$(round(Int, ns)) ns" :
                                 ns < 1e6 ? "$(round(ns/1e3, digits=1)) μs" :
@@ -95,15 +96,15 @@ jobs:
               println("| Benchmark | Time (median) | Memory | Allocs |")
               println("|-----------|---------------|--------|--------|")
               for name in sort(collect(keys(benchmarks)))
-                b = benchmarks[Symbol(name)]
-                println("| $name | $(format_time(b.time_ns.median)) | $(format_mem(b.memory_bytes)) | $(b.allocations) |")
+                b = benchmarks[name]
+                println("| $name | $(format_time(b["time_ns"]["median"])) | $(format_mem(b["memory_bytes"])) | $(b["allocations"]) |")
               end
-            ' >> $GITHUB_STEP_SUMMARY
+            ' >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Comment PR with link
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -143,7 +144,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Get commit info
-          COMMIT_SHA=$(git rev-parse HEAD)
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
 
@@ -167,25 +167,25 @@ jobs:
 
           # Update index
           julia --project=/tmp/benchmark -e '
-            import JSON3
+            import JSON
 
             results_dir = "benchmarks/results"
             files = filter(f -> endswith(f, ".json") && f != "latest.json" && f != "index.json", readdir(results_dir))
 
             index = []
             for f in files
-              data = JSON3.read(read(joinpath(results_dir, f), String))
+              data = JSON.parse(read(joinpath(results_dir, f), String))
               push!(index, Dict(
                 "file" => f,
-                "timestamp" => get(data, :timestamp, "unknown"),
-                "commit" => get(get(data, :git, Dict()), :commit, "unknown"),
-                "branch" => get(get(data, :git, Dict()), :branch, "unknown"),
+                "timestamp" => get(data, "timestamp", "unknown"),
+                "commit" => get(get(data, "git", Dict()), "commit", "unknown"),
+                "branch" => get(get(data, "git", Dict()), "branch", "unknown"),
               ))
             end
 
             sort!(index, by=x->x["timestamp"], rev=true)
             open(joinpath(results_dir, "index.json"), "w") do io
-              JSON3.pretty(io, index)
+              JSON.json(io, index; pretty = true)
             end
           '
 
@@ -195,7 +195,7 @@ jobs:
           git push origin gh-pages
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results
           path: benchmark-output/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
       - run: julia --project=.format .format/format.jl
       - run: git diff --color --exit-code
 
@@ -73,15 +73,15 @@ jobs:
             os: macOS-latest
             arch: aarch64
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
           include-all-prereleases: true
           force-arch: ${{ matrix.force_arch || false }}
-      - uses: pandoc/actions/setup@v1
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1.11.4
         continue-on-error: ${{ matrix.version == 'nightly' }}

--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -9,6 +9,6 @@ jobs:
   register:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/RegisterAction@latest
+      - uses: julia-actions/RegisterAction@d391a7f14ee6db8ad3f8cd26f6da1a6c6fd5b7fb # v0.3.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,4 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,14 +5,14 @@
 
 import BenchmarkTools
 import CommonMark
-import JSON3
+import JSON
 
 const SUITE = BenchmarkTools.BenchmarkGroup()
 
 # Load test data
 const SPEC_MD =
     read(joinpath(@__DIR__, "..", "test", "samples", "cmark", "spec.md"), String)
-const SPEC_JSON = JSON3.read(read(joinpath(@__DIR__, "..", "test", "spec.json"), String))
+const SPEC_JSON = JSON.parse(read(joinpath(@__DIR__, "..", "test", "spec.json"), String))
 
 # Smaller test inputs for micro-benchmarks
 const SIMPLE_MD = """
@@ -87,7 +87,7 @@ SUITE["parse"]["spec_md"] = BenchmarkTools.@benchmarkable $PARSER($SPEC_MD)
 # All spec JSON cases
 SUITE["parse"]["spec_cases_all"] = BenchmarkTools.@benchmarkable begin
     for case in $SPEC_JSON
-        $PARSER(case.markdown)
+        $PARSER(case["markdown"])
     end
 end
 

--- a/benchmark/compare.jl
+++ b/benchmark/compare.jl
@@ -1,11 +1,11 @@
 # Benchmark comparison script
 # Generates markdown report comparing two benchmark results
 
-import JSON3
+import JSON
 import Printf: @sprintf
 
 function load_results(path)
-    JSON3.read(read(path, String))
+    JSON.parse(read(path, String))
 end
 
 function format_time(ns)
@@ -66,8 +66,8 @@ function compare_and_report(baseline_path, current_path, output_path)
     baseline = load_results(baseline_path)
     current = load_results(current_path)
 
-    base_benchmarks = baseline.benchmarks
-    curr_benchmarks = current.benchmarks
+    base_benchmarks = baseline["benchmarks"]
+    curr_benchmarks = current["benchmarks"]
 
     # Collect all benchmark names
     all_names = union(keys(base_benchmarks), keys(curr_benchmarks))
@@ -79,11 +79,11 @@ function compare_and_report(baseline_path, current_path, output_path)
     println(io)
     println(
         io,
-        "**Baseline:** `$(get(get(baseline, :git, Dict()), :commit, "unknown")[1:min(7,end)])`",
+        "**Baseline:** `$(get(get(baseline, "git", Dict()), "commit", "unknown")[1:min(7,end)])`",
     )
     println(
         io,
-        "**Current:** `$(get(get(current, :git, Dict()), :commit, "unknown")[1:min(7,end)])`",
+        "**Current:** `$(get(get(current, "git", Dict()), "commit", "unknown")[1:min(7,end)])`",
     )
     println(io)
 
@@ -103,20 +103,20 @@ function compare_and_report(baseline_path, current_path, output_path)
     improvements = String[]
 
     for name in sorted_names
-        base = get(base_benchmarks, Symbol(name), nothing)
-        curr = get(curr_benchmarks, Symbol(name), nothing)
+        base = get(base_benchmarks, name, nothing)
+        curr = get(curr_benchmarks, name, nothing)
 
         if base === nothing || curr === nothing
             println(io, "| $name | - | - | - | ⚪ new/removed |")
             continue
         end
 
-        base_time = base.time_ns.median
-        curr_time = curr.time_ns.median
-        base_mem = base.memory_bytes
-        curr_mem = curr.memory_bytes
-        base_alloc = base.allocations
-        curr_alloc = curr.allocations
+        base_time = base["time_ns"]["median"]
+        curr_time = curr["time_ns"]["median"]
+        base_mem = base["memory_bytes"]
+        curr_mem = curr["memory_bytes"]
+        base_alloc = base["allocations"]
+        curr_alloc = curr["allocations"]
 
         time_change = format_change(base_time, curr_time)
         mem_change = format_change(base_mem, curr_mem)

--- a/benchmark/run.jl
+++ b/benchmark/run.jl
@@ -5,7 +5,7 @@
 # Outputs JSON with benchmark results and metadata for historical tracking.
 
 import BenchmarkTools
-import JSON3
+import JSON
 import Dates
 
 include("benchmarks.jl")
@@ -96,14 +96,14 @@ function main()
     if output_file !== nothing
         mkpath(dirname(output_file))
         open(output_file, "w") do io
-            JSON3.pretty(io, results)
+            JSON.json(io, results; pretty = true)
         end
         println("\nResults written to: $output_file")
     else
         println("\n", "="^60)
         println("RESULTS")
         println("="^60)
-        JSON3.pretty(stdout, results)
+        JSON.json(stdout, results; pretty = true)
         println()
     end
 


### PR DESCRIPTION
Pin every GitHub Action to its release commit SHA with a trailing version comment. A moved tag silently changes what CI runs.

Quote `$GITHUB_ENV` and `$GITHUB_STEP_SUMMARY` redirects in `benchmark.yml`, drop the unused `COMMIT_SHA`, and mark the Julia block's `$` interpolations as intentional to clear shellcheck.

Give dependabot a 7-day cooldown and group github-actions updates into a single PR.

Migrate the benchmark suite from JSON3 to JSON.jl, the maintained successor. `JSON.parse` returns string-keyed objects, so reads use bracket access and writes use `JSON.json(io, x; pretty=true)`.