### PR TITLE
fix: 12 verified bugs across parser, writers, extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `ReferenceLinkRule` crashing with `StringIndexError` on reference definitions whose label contains multibyte characters [#154]
+- Fix `TableRule` crashing with `BoundsError` on a separator row containing no dashes (e.g. `|::|`); such a row is no longer treated as a table [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `ShortcodeRule` corrupting keyword-argument keys that contain multibyte characters (e.g. `kéy=val`) [#154]
 - Fix `insert_after`/`insert_before` corrupting the shared `NULL_NODE` sentinel when called on a parentless node [#154]
 - Fix `DefinitionListRule` JSON output emitting terms and definitions as flat siblings instead of Pandoc's nested (term, definitions) pairs [#154]
+- Fix Typst writer producing inline code whose backticks merged with the delimiters or were misread as a language tag (e.g. `` `code` ``) [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix `ReferenceLinkRule` crashing with `StringIndexError` on reference definitions whose label contains multibyte characters [#154]
+
 ## [v1.0.2] - 2026-05-29
 
 ### Fixed
@@ -477,3 +481,4 @@ Initial release.
 [#141]: https://github.com/MichaelHatherly/CommonMark.jl/issues/141
 [#145]: https://github.com/MichaelHatherly/CommonMark.jl/issues/145
 [#150]: https://github.com/MichaelHatherly/CommonMark.jl/issues/150
+[#154]: https://github.com/MichaelHatherly/CommonMark.jl/issues/154

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix link reference definition keeping an invalid title (text after the title on the same line) instead of discarding it [#154]
 - Fix link destination parser accepting an unbalanced `(` (e.g. `[a](b(c )`) instead of rejecting the link [#154]
 - Fix link label length limit rejecting spec-valid labels of 998 and 999 characters (off-by-one against the 999-character maximum) [#154]
+- Fix numeric character references for surrogate (`&#xD800;`) and out-of-range (`&#1114112;`) codepoints decoding to invalid characters instead of U+FFFD [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix link label length limit rejecting spec-valid labels of 998 and 999 characters (off-by-one against the 999-character maximum) [#154]
 - Fix numeric character references for surrogate (`&#xD800;`) and out-of-range (`&#1114112;`) codepoints decoding to invalid characters instead of U+FFFD [#154]
 - Fix HTML writer emitting node-metadata attribute values unescaped, allowing a `"` or `<` in an attribute (e.g. via `AttributeRule`) to break out of the attribute [#154]
+- Fix LaTeX writer not escaping link and image destinations, so a URL with `%`, `_`, or `#` produced output that failed to compile [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `ReferenceLinkRule` crashing with `StringIndexError` on reference definitions whose label contains multibyte characters [#154]
 - Fix `TableRule` crashing with `BoundsError` on a separator row containing no dashes (e.g. `|::|`); such a row is no longer treated as a table [#154]
+- Fix link reference definition keeping an invalid title (text after the title on the same line) instead of discarding it [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `ReferenceLinkRule` crashing with `StringIndexError` on reference definitions whose label contains multibyte characters [#154]
 - Fix `TableRule` crashing with `BoundsError` on a separator row containing no dashes (e.g. `|::|`); such a row is no longer treated as a table [#154]
 - Fix link reference definition keeping an invalid title (text after the title on the same line) instead of discarding it [#154]
+- Fix link destination parser accepting an unbalanced `(` (e.g. `[a](b(c )`) instead of rejecting the link [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `TableRule` crashing with `BoundsError` on a separator row containing no dashes (e.g. `|::|`); such a row is no longer treated as a table [#154]
 - Fix link reference definition keeping an invalid title (text after the title on the same line) instead of discarding it [#154]
 - Fix link destination parser accepting an unbalanced `(` (e.g. `[a](b(c )`) instead of rejecting the link [#154]
+- Fix link label length limit rejecting spec-valid labels of 998 and 999 characters (off-by-one against the 999-character maximum) [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix numeric character references for surrogate (`&#xD800;`) and out-of-range (`&#1114112;`) codepoints decoding to invalid characters instead of U+FFFD [#154]
 - Fix HTML writer emitting node-metadata attribute values unescaped, allowing a `"` or `<` in an attribute (e.g. via `AttributeRule`) to break out of the attribute [#154]
 - Fix LaTeX writer not escaping link and image destinations, so a URL with `%`, `_`, or `#` produced output that failed to compile [#154]
+- Fix `ShortcodeRule` corrupting keyword-argument keys that contain multibyte characters (e.g. `kéy=val`) [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix link destination parser accepting an unbalanced `(` (e.g. `[a](b(c )`) instead of rejecting the link [#154]
 - Fix link label length limit rejecting spec-valid labels of 998 and 999 characters (off-by-one against the 999-character maximum) [#154]
 - Fix numeric character references for surrogate (`&#xD800;`) and out-of-range (`&#1114112;`) codepoints decoding to invalid characters instead of U+FFFD [#154]
+- Fix HTML writer emitting node-metadata attribute values unescaped, allowing a `"` or `<` in an attribute (e.g. via `AttributeRule`) to break out of the attribute [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix LaTeX writer not escaping link and image destinations, so a URL with `%`, `_`, or `#` produced output that failed to compile [#154]
 - Fix `ShortcodeRule` corrupting keyword-argument keys that contain multibyte characters (e.g. `kéy=val`) [#154]
 - Fix `insert_after`/`insert_before` corrupting the shared `NULL_NODE` sentinel when called on a parentless node [#154]
+- Fix `DefinitionListRule` JSON output emitting terms and definitions as flat siblings instead of Pandoc's nested (term, definitions) pairs [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix HTML writer emitting node-metadata attribute values unescaped, allowing a `"` or `<` in an attribute (e.g. via `AttributeRule`) to break out of the attribute [#154]
 - Fix LaTeX writer not escaping link and image destinations, so a URL with `%`, `_`, or `#` produced output that failed to compile [#154]
 - Fix `ShortcodeRule` corrupting keyword-argument keys that contain multibyte characters (e.g. `kéy=val`) [#154]
+- Fix `insert_after`/`insert_before` corrupting the shared `NULL_NODE` sentinel when called on a parentless node [#154]
 
 ## [v1.0.2] - 2026-05-29
 

--- a/src/ast.jl
+++ b/src/ast.jl
@@ -244,7 +244,7 @@ function insert_after(node::Node, sibling::Node)
     sibling.prv = node
     node.nxt = sibling
     sibling.parent = node.parent
-    if isnull(sibling.nxt)
+    if isnull(sibling.nxt) && !isnull(sibling.parent)
         sibling.parent.last_child = sibling
     end
 end
@@ -263,7 +263,7 @@ function insert_before(node::Node, sibling::Node)
     sibling.nxt = node
     node.prv = sibling
     sibling.parent = node.parent
-    if isnull(sibling.prv)
+    if isnull(sibling.prv) && !isnull(sibling.parent)
         sibling.parent.first_child = sibling
     end
 end

--- a/src/extensions/definitionlists.jl
+++ b/src/extensions/definitionlists.jl
@@ -404,7 +404,18 @@ function write_json(::DefinitionList, ctx, node, enter)
         push_container!(ctx, items)
     else
         items = pop_container!(ctx)
-        push_element!(ctx, json_el(ctx, "DefinitionList", items))
+        # Pandoc's DefinitionList content is a list of (term, [definitions])
+        # pairs. The terms and descriptions arrive as a flat, tagged sequence;
+        # fold each run of descriptions under its preceding term.
+        pairs = Any[]
+        for (tag, content) in items
+            if tag === :term
+                push!(pairs, Any[content, Any[]])
+            else
+                push!(pairs[end][2], content)
+            end
+        end
+        push_element!(ctx, json_el(ctx, "DefinitionList", pairs))
     end
 end
 
@@ -414,9 +425,7 @@ function write_json(::DefinitionTerm, ctx, node, enter)
         push_container!(ctx, inlines)
     else
         inlines = pop_container!(ctx)
-        # Store term inlines as the first element of a [term, [defs...]] pair
-        # We need to collect definitions that follow
-        push_element!(ctx, inlines)
+        push_element!(ctx, (:term, inlines))
     end
 end
 
@@ -426,6 +435,6 @@ function write_json(::DefinitionDescription, ctx, node, enter)
         push_container!(ctx, blocks)
     else
         blocks = pop_container!(ctx)
-        push_element!(ctx, blocks)
+        push_element!(ctx, (:desc, blocks))
     end
 end

--- a/src/extensions/referencelinks.jl
+++ b/src/extensions/referencelinks.jl
@@ -299,7 +299,7 @@ block_rule(::ReferenceLinkRule) =
         label = chop(label_with_brackets; head = 1, tail = 1)  # remove [ and ]
 
         # Parse rest of line for destination and title
-        rest = SubString(ln, length(m.match) + 1)
+        rest = SubString(ln, ncodeunits(m.match) + 1)
 
         # Skip leading whitespace
         rest_stripped = lstrip(rest)

--- a/src/extensions/shortcodes.jl
+++ b/src/extensions/shortcodes.jl
@@ -156,13 +156,11 @@ function _parse_shortcode_args(s::AbstractString)
     isempty(s) && return (args, kwargs)
     buf = IOBuffer()
     in_quote = nothing  # nothing, '"', or '\''
-    eq_pos = 0          # position of first unquoted '=' in current token
-    token_len = 0
+    eq_pos = 0          # byte position of first unquoted '=' in current token
     escaped = false
     for c in s
         if escaped
             write(buf, c)
-            token_len += 1
             escaped = false
         elseif in_quote !== nothing && c == '\\'
             escaped = true
@@ -171,19 +169,16 @@ function _parse_shortcode_args(s::AbstractString)
                 in_quote = nothing
             else
                 write(buf, c)
-                token_len += 1
             end
         elseif c == '"' || c == '\''
             in_quote = c
         elseif isspace(c)
             _flush_shortcode_token!(buf, args, kwargs, eq_pos)
             eq_pos = 0
-            token_len = 0
         else
             write(buf, c)
-            token_len += 1
             if c == '=' && eq_pos == 0
-                eq_pos = token_len
+                eq_pos = position(buf)
             end
         end
     end

--- a/src/extensions/tables.jl
+++ b/src/extensions/tables.jl
@@ -110,22 +110,26 @@ function gfm_table(parser::Parser, container::Node)
             if valid_table_spec(spec_str)
                 # Parse the table spec line.
                 spec = parse_table_spec(spec_str)
-                table = Node(Table(spec), container.sourcepos)
-                # Build header row with cells for each column.
-                head = Node(TableHeader(), container.sourcepos)
-                append_child(table, head)
-                row = Node(TableRow(), container.sourcepos)
-                row.literal = header
-                append_child(head, row)
-                # Insert the empty body for the table.
-                body = Node(TableBody(), container.sourcepos)
-                append_child(table, body)
-                # Splice the newly created table in place of the paragraph.
-                insert_after(container, table)
-                unlink(container)
-                parser.tip = table
-                advance_to_end(parser)
-                return 2
+                # A spec with no dash-delimited columns yields no columns and is
+                # not a table; leave the paragraph untouched.
+                if !isempty(spec)
+                    table = Node(Table(spec), container.sourcepos)
+                    # Build header row with cells for each column.
+                    head = Node(TableHeader(), container.sourcepos)
+                    append_child(table, head)
+                    row = Node(TableRow(), container.sourcepos)
+                    row.literal = header
+                    append_child(head, row)
+                    # Insert the empty body for the table.
+                    body = Node(TableBody(), container.sourcepos)
+                    append_child(table, body)
+                    # Splice the newly created table in place of the paragraph.
+                    insert_after(container, table)
+                    unlink(container)
+                    parser.tip = table
+                    advance_to_end(parser)
+                    return 2
+                end
             end
         end
         if container.t isa Table

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -82,6 +82,9 @@ function parse_link_destination(parser::InlineParser)
         if position(parser) === savepos && c !== ')'
             return nothing
         end
+        if openparens != 0
+            return nothing
+        end
         res = String(bytes(parser, savepos, position(parser) - 1))
         return normalize_uri(unescape_string(res))
     else

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -95,7 +95,7 @@ end
 
 function parse_link_label(parser::InlineParser)
     m = consume(parser, match(reLinkLabel, parser))
-    return (m === nothing || length(m.match) ≥ 1000) ? 0 : ncodeunits(m.match)
+    return (m === nothing || length(m.match) > 1001) ? 0 : ncodeunits(m.match)
 end
 
 function parse_open_bracket(parser::InlineParser, block::Node)

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -273,7 +273,7 @@ function parse_reference(parser::InlineParser, s::AbstractString, refmap::Dict)
         else
             # The potential title we found is not at the line end, but it could
             # still be a legal link reference if we discard the title.
-            title == ""
+            title = ""
             # Rewind to before spaces.
             seek(parser, beforetitle)
             # Or instead check if the link URL is at the line end.

--- a/src/utils/entitytrans.jl
+++ b/src/utils/entitytrans.jl
@@ -24,13 +24,7 @@ function HTMLunescape(s)
         else
             Base.parse(UInt32, s[3:end-1])
         end
-        num == 0 && return "\uFFFD"
-        try
-            return string(Char(num))
-        catch err
-            err isa Base.CodePointError || rethrow(err)
-            return "\uFFFD"
-        end
+        return (num == 0 || !isvalid(Char, num)) ? "\uFFFD" : string(Char(num))
     else
         return get(ENTITY_DATA, s, s)
     end

--- a/src/writers/html.jl
+++ b/src/writers/html.jl
@@ -272,11 +272,14 @@ function attributes(r, n, out = [])
             end
         end
     end
-    for each in (out, something(n.meta, ()))
+    # Call-site values in `out` are already escaped; metadata values are raw and
+    # must be escaped here to avoid breaking out of the attribute.
+    for (source, escape) in ((out, false), (something(n.meta, ()), true))
         # Sort Dict keys for deterministic attribute ordering across Julia versions
-        pairs_iter = each isa AbstractDict ? sort!(collect(each), by = first) : each
+        pairs_iter = source isa AbstractDict ? sort!(collect(source), by = first) : source
         for (key, value) in pairs_iter
             value = isa(value, AbstractString) ? value : join(value, " ")
+            escape && (value = escape_xml(value))
             if haskey(dict, key)
                 dict[key] = "$(dict[key]) $value"
             else

--- a/src/writers/latex.jl
+++ b/src/writers/latex.jl
@@ -73,7 +73,7 @@ function write_latex(link::Link, w, node, ent)
         # these, so branch based on it to allow both types of links to be used.
         # Generating `\url` commands is not supported.
         type, n = startswith(link.destination, '#') ? ("hyperlink", 1) : ("href", 0)
-        literal(w, "\\$type{$(chop(link.destination; head=n, tail=0))}{")
+        literal(w, "\\$type{$(latex_escape(chop(link.destination; head=n, tail=0)))}{")
     else
         literal(w, "}")
     end
@@ -84,7 +84,12 @@ function write_latex(image::Image, w, node, ent)
         cr(w)
         literal(w, "\\begin{figure}\n")
         literal(w, "\\centering\n")
-        literal(w, "\\includegraphics[max width=\\linewidth]{", image.destination, "}\n")
+        literal(
+            w,
+            "\\includegraphics[max width=\\linewidth]{",
+            latex_escape(image.destination),
+            "}\n",
+        )
         literal(w, "\\caption{")
     else
         literal(w, "}\n")

--- a/src/writers/typst.jl
+++ b/src/writers/typst.jl
@@ -63,12 +63,24 @@ function write_typst(::Union{SoftBreak,LineBreak}, w, node, ent)
 end
 
 function write_typst(::Code, w, node, ent)
-    num = foldl(eachmatch(r"`+", node.literal); init = 0) do a, b
+    content = node.literal
+    maxrun = foldl(eachmatch(r"`+", content); init = 0) do a, b
         max(a, length(b.match))
     end
-    literal(w, "`"^(num == 1 ? 3 : 1))
-    literal(w, node.literal)
-    literal(w, "`"^(num == 1 ? 3 : 1))
+    if maxrun == 0
+        literal(w, "`", content, "`")
+    else
+        # Typst closes a raw span at a run of N backticks and parses a language
+        # tag after 3+ opening backticks. Use N greater than the longest run in
+        # the content (and at least 3, since `` is the empty-raw special case),
+        # pad with a leading space to suppress the language tag, and a trailing
+        # space when the content ends in a backtick so it does not merge with
+        # the closing delimiter. Typst trims both pad spaces.
+        delim = "`"^max(3, maxrun + 1)
+        literal(w, delim, " ", content)
+        endswith(content, '`') && literal(w, " ")
+        literal(w, delim)
+    end
 end
 
 write_typst(::HtmlInline, w, node, ent) = nothing

--- a/test/ast.jl
+++ b/test/ast.jl
@@ -26,3 +26,18 @@
     @test root.first_child.literal == "prepend_child"
     @test root.last_child.literal == "prepend_child"
 end
+
+@testitem "insert preserves NULL_NODE sentinel" tags = [:core] begin
+    using CommonMark
+    using Test
+
+    # Inserting next to a parentless node must not write through to the shared
+    # NULL_NODE sentinel, whose child fields stay undefined.
+    root = CommonMark.Node(CommonMark.Paragraph())
+    CommonMark.insert_after(root, CommonMark.Node(CommonMark.Text()))
+    @test !isdefined(CommonMark.NULL_NODE, :last_child)
+
+    root = CommonMark.Node(CommonMark.Paragraph())
+    CommonMark.insert_before(root, CommonMark.Node(CommonMark.Text()))
+    @test !isdefined(CommonMark.NULL_NODE, :first_child)
+end

--- a/test/extensions/definitionlists.jl
+++ b/test/extensions/definitionlists.jl
@@ -109,3 +109,27 @@
         @test occursin("DefinitionList", j)
     end
 end
+
+@testitem "definitionlists pandoc json structure" tags = [:extensions, :definitionlists] setup =
+    [Utilities] begin
+    using CommonMark
+    using Test
+
+    p = create_parser(DefinitionListRule())
+
+    # Pandoc DefinitionList content is [ ([Inline], [[Block]]) ]: a list of
+    # (term, [definitions]) pairs, not a flat list of terms and definitions.
+    d = json(Dict, p("Term 1\n\n:   Def 1a\n\n:   Def 1b\n"))
+    dl = d["blocks"][1]
+    @test dl["t"] == "DefinitionList"
+
+    pairs = dl["c"]
+    @test length(pairs) == 1            # one term
+
+    term, defs = pairs[1]
+    @test term[1]["t"] == "Str"         # term inlines
+    @test term[1]["c"] == "Term"
+    @test length(defs) == 2             # two definitions for the term
+    @test defs[1][1]["t"] == "Para"     # each definition is a list of blocks
+    @test defs[2][1]["t"] == "Para"
+end

--- a/test/extensions/referencelinks.jl
+++ b/test/extensions/referencelinks.jl
@@ -188,3 +188,18 @@
         "referencelinks",
     )
 end
+
+@testitem "referencelinks multibyte label" tags = [:extensions, :referencelinks] setup =
+    [Utilities] begin
+    using CommonMark
+    using Test
+
+    p = create_parser(ReferenceLinkRule())
+
+    # Regression: a multibyte label must not crash the parse (byte-vs-char index).
+    ast = p("[😀]: http://x.com\n\n[😀]")
+    @test html(ast) == "<p><a href=\"http://x.com\">😀</a></p>\n"
+
+    ast = p("[日本語]: http://x.com\n\n[日本語]")
+    @test html(ast) == "<p><a href=\"http://x.com\">日本語</a></p>\n"
+end

--- a/test/extensions/shortcodes.jl
+++ b/test/extensions/shortcodes.jl
@@ -356,3 +356,22 @@
         @test html(ast) == "<p>html</p>\n"
     end
 end
+
+@testitem "shortcodes multibyte kwargs" tags = [:extensions, :shortcodes] setup =
+    [Utilities] begin
+    using CommonMark
+    using Test
+
+    # A kwarg key with multibyte characters must split on the byte position of
+    # '=', not a character count used as a byte index.
+    args, kwargs = CommonMark._parse_shortcode_args("kéy=val café=z")
+    @test args == String[]
+    @test kwargs == ["kéy" => "val", "café" => "z"]
+
+    # Through the parser.
+    p = create_parser(ShortcodeRule())
+    ast = p("x {{< ref kéy=val >}} y")
+    shortcodes = [n.t for (n, entering) in ast if entering && n.t isa CommonMark.Shortcode]
+    @test length(shortcodes) == 1
+    @test shortcodes[1].kwargs == ["kéy" => "val"]
+end

--- a/test/extensions/tables.jl
+++ b/test/extensions/tables.jl
@@ -121,3 +121,22 @@
     @test length(tables[2].t.spec) == 3
     test_table("consecutive", ast, "tables")
 end
+
+@testitem "tables dashless separator" tags = [:extensions, :tables] setup = [Utilities] begin
+    using CommonMark
+    using Test
+
+    p = create_parser(TableRule())
+
+    # Regression: a separator row with no dashes is not a valid table spec.
+    # It must not crash (empty spec -> spec[0]); the block stays a paragraph.
+    ast = p("|a|b|\n|::|\n|c|d|\n")
+    tables = [n for (n, entering) in ast if entering && n.t isa CommonMark.Table]
+    @test isempty(tables)
+    @test !occursin("<table>", html(ast))
+
+    # A genuine table alongside still parses.
+    ast = p("|a|b|\n|--|--|\n|c|d|\n")
+    tables = [n for (n, entering) in ast if entering && n.t isa CommonMark.Table]
+    @test length(tables) == 1
+end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -134,3 +134,19 @@
         @test ast.first_child.t isa CommonMark.Paragraph
     end
 end
+
+@testitem "reference definition discards invalid title" tags = [:core] begin
+    using CommonMark
+    using Test
+    p = Parser()
+
+    # A title followed by other text on the line is invalid; the definition is
+    # still valid using the URL alone, and the title must be discarded.
+    ast = p("[foo]: /url\n\"title\" extra\n\n[foo]\n")
+    @test occursin("<a href=\"/url\">foo</a>", html(ast))
+    @test !occursin("title=", html(ast))
+
+    # Control: a clean title on its own line is kept.
+    ast = p("[foo]: /url\n\"title\"\n\n[foo]\n")
+    @test occursin("<a href=\"/url\" title=\"title\">foo</a>", html(ast))
+end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -165,3 +165,19 @@ end
     ast = p("[a](b(c) )\n")
     @test occursin("<a href=\"b(c)\">a</a>", html(ast))
 end
+
+@testitem "link label length boundary" tags = [:core] begin
+    using CommonMark
+    using Test
+    p = Parser()
+
+    # The spec allows up to 999 characters inside the brackets.
+    label999 = repeat("a", 999)
+    ast = p("[$label999]\n\n[$label999]: /url\n")
+    @test occursin("<a href=\"/url\">", html(ast))
+
+    # 1000 characters exceeds the limit and must not resolve.
+    label1000 = repeat("a", 1000)
+    ast = p("[$label1000]\n\n[$label1000]: /url\n")
+    @test !occursin("<a href", html(ast))
+end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -181,3 +181,18 @@ end
     ast = p("[$label1000]\n\n[$label1000]: /url\n")
     @test !occursin("<a href", html(ast))
 end
+
+@testitem "numeric entity validity" tags = [:core] begin
+    using CommonMark
+    using Test
+    p = Parser()
+    decode(s) = p(s).first_child.first_child.literal
+
+    # Surrogate and out-of-range codepoints must decode to U+FFFD.
+    @test decode("&#xD800;") == "�"
+    @test decode("&#1114112;") == "�"
+
+    # Control: valid codepoints decode normally.
+    @test decode("&#65;") == "A"
+    @test decode("&#x10FFFF;") == "\U10FFFF"
+end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -150,3 +150,18 @@ end
     ast = p("[foo]: /url\n\"title\"\n\n[foo]\n")
     @test occursin("<a href=\"/url\" title=\"title\">foo</a>", html(ast))
 end
+
+@testitem "link destination rejects unbalanced parens" tags = [:core] begin
+    using CommonMark
+    using Test
+    p = Parser()
+
+    # An unparenthesised destination with an unbalanced '(' is not a valid link.
+    ast = p("[a](b(c )\n")
+    @test !occursin("<a href", html(ast))
+    @test occursin("[a](b(c )", html(ast))
+
+    # Control: balanced parens still form a link.
+    ast = p("[a](b(c) )\n")
+    @test occursin("<a href=\"b(c)\">a</a>", html(ast))
+end

--- a/test/writers/html.jl
+++ b/test/writers/html.jl
@@ -90,3 +90,20 @@
         html,
     )
 end
+
+@testitem "html attribute value escaping" tags = [:writers, :html] setup = [Utilities] begin
+    using CommonMark
+    using Test
+
+    p = create_parser(AttributeRule())
+
+    # A double quote inside an attribute value must be escaped, not emitted raw
+    # (raw would break out of the attribute and allow injection).
+    out = html(p("{data-x='a\"b'}\nparagraph\n"))
+    @test occursin("data-x=\"a&quot;b\"", out)
+    @test !occursin("data-x=\"a\"b\"", out)
+
+    # Angle brackets in an attribute value are escaped too.
+    out = html(p("{data-y='<x>'}\nparagraph\n"))
+    @test occursin("data-y=\"&lt;x&gt;\"", out)
+end

--- a/test/writers/latex.jl
+++ b/test/writers/latex.jl
@@ -79,3 +79,23 @@
     # Escapes.
     test("references/latex/escapes.tex", "^~\\&%\$#_{}", latex)
 end
+
+@testitem "latex destination escaping" tags = [:writers, :latex] setup = [Utilities] begin
+    using CommonMark
+    using Test
+
+    p = create_parser()
+
+    # LaTeX-special characters in a link destination must be escaped so the
+    # output compiles (a bare % comments out the rest of the line).
+    out = latex(p("[x](http://e.com/a_b%20c#frag)\n"))
+    @test occursin("\\%", out)
+    @test occursin("\\_", out)
+    @test occursin("\\#", out)
+    @test !occursin("a_b%20c#frag", out)
+
+    # Image destinations are escaped too.
+    out = latex(p("![x](img_1%2.png)\n"))
+    @test occursin("\\_", out)
+    @test occursin("\\%", out)
+end

--- a/test/writers/typst.jl
+++ b/test/writers/typst.jl
@@ -79,3 +79,21 @@
     # Escapes.
     test("references/typst/escapes.typ", "^~\\&%\$#_{}", typst)
 end
+
+@testitem "typst inline code with backticks" tags = [:writers, :typst] setup = [Utilities] begin
+    using CommonMark
+    using Test
+
+    p = create_parser()
+    code(s) = strip(typst(p(s)))
+
+    # Content containing backticks must not merge with the delimiters, and an
+    # identifier start must not become a spurious language tag. Typst closes a
+    # raw span at a run of N backticks and trims a single pad space each side.
+    @test code("`` `code` ``") == "``` `code` ```"
+    @test code("``a`b``") == "``` a`b```"
+
+    # No backticks: simplest single-backtick inline raw, unchanged.
+    @test code("`plain`") == "`plain`"
+    @test code("``c``") == "`c`"
+end


### PR DESCRIPTION
Fixes 12 bugs found by a code audit. Each was reproduced before fixing and locked down with a regression test. The full suite (2428 tests) and CommonMark spec compliance stay green.

Two are crashes that aborted the whole document parse:
- `ReferenceLinkRule`: a character count used as a byte offset crashed on multibyte labels.
- `TableRule`: a dashless separator row (e.g. `|::|`) passed validation but parsed to an empty spec, then indexed `spec[0]`.

Link parser correctness (against the CommonMark reference):
- Discard an invalid reference-definition title instead of keeping it (`title == ""` was a no-op assignment).
- Reject link destinations with an unbalanced `(`.
- Off-by-one in the 999-character label limit rejected valid 998/999-character labels.

Output and escaping:
- Numeric character references for surrogate and out-of-range codepoints fold to U+FFFD.
- HTML writer escapes attribute values sourced from node metadata, so a `"` cannot break out of the attribute.
- LaTeX writer escapes link and image destinations, so URLs with `%`, `_`, `#` compile.
- Typst inline code containing backticks no longer merges with the delimiters or trips language-tag detection (verified against the Typst lexer).

Other:
- `ShortcodeRule` byte-indexes the kwarg split, fixing keys with multibyte characters.
- `DefinitionListRule` JSON output nests Pandoc `(term, definitions)` pairs.
- `insert_after`/`insert_before` no longer corrupt the shared `NULL_NODE` sentinel on parentless nodes.