### PR TITLE
chore: switch formatter to Runic

### DIFF
--- a/.format/Project.toml
+++ b/.format/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-
-[compat]
-JuliaFormatter = "1"

--- a/.format/format.jl
+++ b/.format/format.jl
@@ -1,6 +1,0 @@
-import Pkg
-Pkg.instantiate()
-
-import JuliaFormatter
-
-JuliaFormatter.format(dirname(@__DIR__))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,20 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
-      - run: julia --project=.format .format/format.jl
-      - run: git diff --color --exit-code
+      - uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
+        with:
+          tool: just
+      - name: Install runic
+        run: |
+          julia --project=@runic --startup-file=no -e 'using Pkg; Pkg.add("Runic")'
+          cat > runic <<'SCRIPT'
+          #!/bin/sh
+          export JULIA_LOAD_PATH="@runic"
+          exec julia --startup-file=no -e 'using Runic; exit(Runic.main(ARGS))' -- "$@"
+          SCRIPT
+          chmod +x runic
+          echo "$PWD" >> "$GITHUB_PATH"
+      - run: just fmt-check
 
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ EOF
 
 ### Code Formatting
 ```bash
-just format
+just fmt        # Format in-place with Runic
+just fmt-check  # Check formatting without modifying (CI)
 ```
 
 ### Building

--- a/benchmark/compare.jl
+++ b/benchmark/compare.jl
@@ -5,11 +5,11 @@ import JSON
 import Printf: @sprintf
 
 function load_results(path)
-    JSON.parse(read(path, String))
+    return JSON.parse(read(path, String))
 end
 
 function format_time(ns)
-    if ns < 1_000
+    return if ns < 1_000
         @sprintf("%.1f ns", ns)
     elseif ns < 1_000_000
         @sprintf("%.2f μs", ns / 1_000)
@@ -21,7 +21,7 @@ function format_time(ns)
 end
 
 function format_memory(bytes)
-    if bytes < 1024
+    return if bytes < 1024
         @sprintf("%d B", bytes)
     elseif bytes < 1024^2
         @sprintf("%.1f KiB", bytes / 1024)
@@ -38,7 +38,7 @@ function format_change(baseline, current)
     end
     ratio = current / baseline
     pct = (ratio - 1) * 100
-    if abs(pct) < 1
+    return if abs(pct) < 1
         "~"
     elseif pct > 0
         @sprintf("+%.1f%%", pct)
@@ -55,7 +55,7 @@ function status_emoji(baseline, current; lower_is_better = true)
     threshold_good = lower_is_better ? 0.95 : 1.05
     threshold_bad = lower_is_better ? 1.05 : 0.95
 
-    if lower_is_better
+    return if lower_is_better
         ratio < threshold_good ? "🟢" : ratio > threshold_bad ? "🔴" : "⚪"
     else
         ratio > threshold_good ? "🟢" : ratio < threshold_bad ? "🔴" : "⚪"
@@ -79,11 +79,11 @@ function compare_and_report(baseline_path, current_path, output_path)
     println(io)
     println(
         io,
-        "**Baseline:** `$(get(get(baseline, "git", Dict()), "commit", "unknown")[1:min(7,end)])`",
+        "**Baseline:** `$(get(get(baseline, "git", Dict()), "commit", "unknown")[1:min(7, end)])`",
     )
     println(
         io,
-        "**Current:** `$(get(get(current, "git", Dict()), "commit", "unknown")[1:min(7,end)])`",
+        "**Current:** `$(get(get(current, "git", Dict()), "commit", "unknown")[1:min(7, end)])`",
     )
     println(io)
 
@@ -127,12 +127,12 @@ function compare_and_report(baseline_path, current_path, output_path)
         # Track significant changes
         if base_time > 0
             ratio = curr_time / base_time
-            if ratio > 1.10
+            if ratio > 1.1
                 push!(
                     regressions,
                     "$name: $(format_time(base_time)) → $(format_time(curr_time)) ($time_change)",
                 )
-            elseif ratio < 0.90
+            elseif ratio < 0.9
                 push!(
                     improvements,
                     "$name: $(format_time(base_time)) → $(format_time(curr_time)) ($time_change)",
@@ -181,5 +181,5 @@ function compare_and_report(baseline_path, current_path, output_path)
     write(output_path, result)
     println(result)
     println("Comparison written to: $output_path")
-    result
+    return result
 end

--- a/benchmark/profile.jl
+++ b/benchmark/profile.jl
@@ -13,7 +13,7 @@ PARSER(SPEC_MD)
 
 # Profile with more iterations for better sampling
 Profile.clear()
-@profile for _ = 1:100
+@profile for _ in 1:100
     PARSER(SPEC_MD)
 end
 

--- a/benchmark/run.jl
+++ b/benchmark/run.jl
@@ -26,7 +26,7 @@ function get_git_info()
     catch
         false
     end
-    (commit = commit, branch = branch, dirty = dirty)
+    return (commit = commit, branch = branch, dirty = dirty)
 end
 
 function extract_trial_stats(trial::BenchmarkTools.Trial)
@@ -34,7 +34,7 @@ function extract_trial_stats(trial::BenchmarkTools.Trial)
     m = trial.memory
     a = trial.allocs
     gc = trial.gctimes
-    (
+    return (
         time_ns = (
             minimum = minimum(t),
             median = BenchmarkTools.median(trial).time,
@@ -50,7 +50,7 @@ function extract_trial_stats(trial::BenchmarkTools.Trial)
 end
 
 function flatten_results(group::BenchmarkTools.BenchmarkGroup, prefix = "")
-    results = Dict{String,Any}()
+    results = Dict{String, Any}()
     for (key, value) in group
         full_key = isempty(prefix) ? string(key) : "$(prefix)/$(key)"
         if value isa BenchmarkTools.BenchmarkGroup
@@ -59,7 +59,7 @@ function flatten_results(group::BenchmarkTools.BenchmarkGroup, prefix = "")
             results[full_key] = extract_trial_stats(value)
         end
     end
-    results
+    return results
 end
 
 function run_benchmarks()
@@ -85,7 +85,7 @@ function run_benchmarks()
         "benchmarks" => flatten_results(results),
     )
 
-    output
+    return output
 end
 
 function main()
@@ -107,7 +107,7 @@ function main()
         println()
     end
 
-    results
+    return results
 end
 
 main()

--- a/ext/CommonMarkMarkdownASTExt.jl
+++ b/ext/CommonMarkMarkdownASTExt.jl
@@ -29,12 +29,12 @@ mast = MarkdownAST.Node(cm)
 """
 function MarkdownAST.Node(cm::CommonMark.Node)
     cm.t isa CommonMark.Document || error("Expected Document root node")
-    _to_mast(cm)
+    return _to_mast(cm)
 end
 
 function MarkdownAST.Node(doc::CommonMark.LazyCommonMarkDoc)
     cm = CommonMark._parse_doc(doc)
-    MarkdownAST.Node(cm)
+    return MarkdownAST.Node(cm)
 end
 
 # Interface implementation for cross-extension conversion
@@ -81,14 +81,14 @@ _cm_to_element(::CommonMark.Document, cm) = MarkdownAST.Document()
 _cm_to_element(::CommonMark.Paragraph, cm) = MarkdownAST.Paragraph()
 
 function _cm_to_element(h::CommonMark.Heading, cm)
-    MarkdownAST.Heading(h.level)
+    return MarkdownAST.Heading(h.level)
 end
 
 _cm_to_element(::CommonMark.BlockQuote, cm) = MarkdownAST.BlockQuote()
 
 function _cm_to_element(l::CommonMark.List, cm)
     ld = l.list_data
-    MarkdownAST.List(ld.type, ld.tight)
+    return MarkdownAST.List(ld.type, ld.tight)
 end
 
 _cm_to_element(::CommonMark.Item, cm) = MarkdownAST.Item()
@@ -97,47 +97,47 @@ function _cm_to_element(cb::CommonMark.CodeBlock, cm)
     # Strip trailing newline that CommonMark adds
     code = cm.literal
     code = endswith(code, '\n') ? chop(code) : code
-    MarkdownAST.CodeBlock(cb.info, code)
+    return MarkdownAST.CodeBlock(cb.info, code)
 end
 
 _cm_to_element(::CommonMark.ThematicBreak, cm) = MarkdownAST.ThematicBreak()
 
 function _cm_to_element(::CommonMark.HtmlBlock, cm)
-    MarkdownAST.HTMLBlock(cm.literal)
+    return MarkdownAST.HTMLBlock(cm.literal)
 end
 
 # Inline elements
 function _cm_to_element(::CommonMark.Text, cm)
-    MarkdownAST.Text(cm.literal)
+    return MarkdownAST.Text(cm.literal)
 end
 
 _cm_to_element(::CommonMark.SoftBreak, cm) = MarkdownAST.SoftBreak()
 _cm_to_element(::CommonMark.LineBreak, cm) = MarkdownAST.LineBreak()
 
 function _cm_to_element(::CommonMark.Code, cm)
-    MarkdownAST.Code(cm.literal)
+    return MarkdownAST.Code(cm.literal)
 end
 
 _cm_to_element(::CommonMark.Emph, cm) = MarkdownAST.Emph()
 _cm_to_element(::CommonMark.Strong, cm) = MarkdownAST.Strong()
 
 function _cm_to_element(l::CommonMark.Link, cm)
-    MarkdownAST.Link(l.destination, l.title)
+    return MarkdownAST.Link(l.destination, l.title)
 end
 
 function _cm_to_element(i::CommonMark.Image, cm)
-    MarkdownAST.Image(i.destination, i.title)
+    return MarkdownAST.Image(i.destination, i.title)
 end
 
 function _cm_to_element(::CommonMark.HtmlInline, cm)
-    MarkdownAST.HTMLInline(cm.literal)
+    return MarkdownAST.HTMLInline(cm.literal)
 end
 
 _cm_to_element(::CommonMark.Backslash, cm) = MarkdownAST.Backslash()
 
 # Tables
 function _cm_to_element(t::CommonMark.Table, cm)
-    MarkdownAST.Table(t.spec)
+    return MarkdownAST.Table(t.spec)
 end
 
 _cm_to_element(::CommonMark.TableHeader, cm) = MarkdownAST.TableHeader()
@@ -147,37 +147,37 @@ _cm_to_element(::CommonMark.TableRows, cm) = nothing  # drop wrapper, keep child
 _cm_to_element(::CommonMark.TableRow, cm) = MarkdownAST.TableRow()
 
 function _cm_to_element(tc::CommonMark.TableCell, cm)
-    MarkdownAST.TableCell(tc.align, tc.header, tc.column)
+    return MarkdownAST.TableCell(tc.align, tc.header, tc.column)
 end
 
 # Extensions with MarkdownAST equivalents
 function _cm_to_element(a::CommonMark.Admonition, cm)
-    MarkdownAST.Admonition(a.category, a.title)
+    return MarkdownAST.Admonition(a.category, a.title)
 end
 
 function _cm_to_element(::CommonMark.Math, cm)
-    MarkdownAST.InlineMath(cm.literal)
+    return MarkdownAST.InlineMath(cm.literal)
 end
 
 function _cm_to_element(::CommonMark.DisplayMath, cm)
-    MarkdownAST.DisplayMath(cm.literal)
+    return MarkdownAST.DisplayMath(cm.literal)
 end
 
 function _cm_to_element(fd::CommonMark.FootnoteDefinition, cm)
-    MarkdownAST.FootnoteDefinition(fd.id)
+    return MarkdownAST.FootnoteDefinition(fd.id)
 end
 
 function _cm_to_element(fl::CommonMark.FootnoteLink, cm)
-    MarkdownAST.FootnoteLink(fl.id)
+    return MarkdownAST.FootnoteLink(fl.id)
 end
 
 function _cm_to_element(jv::CommonMark.JuliaValue, cm)
-    MarkdownAST.JuliaValue(jv.ex, jv.ref)
+    return MarkdownAST.JuliaValue(jv.ex, jv.ref)
 end
 
 function _cm_to_element(je::CommonMark.JuliaExpression, cm)
     # JuliaExpression becomes JuliaValue with just the expression
-    MarkdownAST.JuliaValue(je.ex, nothing)
+    return MarkdownAST.JuliaValue(je.ex, nothing)
 end
 
 # DocStringSection is a wrapper used by docstring parsing - drop it, keep children
@@ -213,7 +213,7 @@ CommonMark.html(cm)
 """
 function CommonMark.Node(mast::MarkdownAST.Node)
     mast.element isa MarkdownAST.Document || error("Expected Document root node")
-    _to_cm(mast)
+    return _to_cm(mast)
 end
 
 function _to_cm(mast::MarkdownAST.Node)
@@ -233,7 +233,7 @@ _mast_to_node(::MarkdownAST.Paragraph, m) = CommonMark.Node(CommonMark.Paragraph
 function _mast_to_node(e::MarkdownAST.Heading, m)
     n = CommonMark.Node(CommonMark.Heading())
     n.t.level = e.level
-    n
+    return n
 end
 
 _mast_to_node(::MarkdownAST.BlockQuote, m) = CommonMark.Node(CommonMark.BlockQuote())
@@ -244,11 +244,11 @@ function _mast_to_node(e::MarkdownAST.List, m)
     n.t.list_data.tight = e.tight
     n.t.list_data.bullet_char = '-'
     n.t.list_data.delimiter = "."
-    n
+    return n
 end
 
 function _mast_to_node(::MarkdownAST.Item, m)
-    CommonMark.Node(CommonMark.Item())
+    return CommonMark.Node(CommonMark.Item())
 end
 
 function _mast_to_node(e::MarkdownAST.CodeBlock, m)
@@ -258,7 +258,7 @@ function _mast_to_node(e::MarkdownAST.CodeBlock, m)
     n.t.fence_char = '`'
     n.t.fence_length = max(3, max_backtick_run(e.code) + 1)
     n.literal = endswith(e.code, '\n') ? e.code : e.code * "\n"
-    n
+    return n
 end
 
 function max_backtick_run(s::AbstractString)
@@ -280,14 +280,14 @@ _mast_to_node(::MarkdownAST.ThematicBreak, m) = CommonMark.Node(CommonMark.Thema
 function _mast_to_node(e::MarkdownAST.HTMLBlock, m)
     n = CommonMark.Node(CommonMark.HtmlBlock())
     n.literal = e.html
-    n
+    return n
 end
 
 # Inline elements
 function _mast_to_node(e::MarkdownAST.Text, m)
     n = CommonMark.Node(CommonMark.Text())
     n.literal = e.text
-    n
+    return n
 end
 
 _mast_to_node(::MarkdownAST.SoftBreak, m) = CommonMark.Node(CommonMark.SoftBreak())
@@ -296,46 +296,46 @@ _mast_to_node(::MarkdownAST.LineBreak, m) = CommonMark.Node(CommonMark.LineBreak
 function _mast_to_node(e::MarkdownAST.Code, m)
     n = CommonMark.Node(CommonMark.Code())
     n.literal = e.code
-    n
+    return n
 end
 
 function _mast_to_node(::MarkdownAST.Emph, m)
     n = CommonMark.Node(CommonMark.Emph())
     n.literal = "*"  # Delimiter hint for markdown writer
-    n
+    return n
 end
 
 function _mast_to_node(::MarkdownAST.Strong, m)
     n = CommonMark.Node(CommonMark.Strong())
     n.literal = "**"  # Delimiter hint for markdown writer
-    n
+    return n
 end
 
 function _mast_to_node(e::MarkdownAST.Link, m)
     n = CommonMark.Node(CommonMark.Link())
     n.t.destination = e.destination
     n.t.title = e.title
-    n
+    return n
 end
 
 function _mast_to_node(e::MarkdownAST.Image, m)
     n = CommonMark.Node(CommonMark.Image())
     n.t.destination = e.destination
     n.t.title = e.title
-    n
+    return n
 end
 
 function _mast_to_node(e::MarkdownAST.HTMLInline, m)
     n = CommonMark.Node(CommonMark.HtmlInline())
     n.literal = e.html
-    n
+    return n
 end
 
 _mast_to_node(::MarkdownAST.Backslash, m) = CommonMark.Node(CommonMark.Backslash())
 
 # Tables
 function _mast_to_node(e::MarkdownAST.Table, m)
-    CommonMark.Node(CommonMark.Table(e.spec))
+    return CommonMark.Node(CommonMark.Table(e.spec))
 end
 
 _mast_to_node(::MarkdownAST.TableHeader, m) = CommonMark.Node(CommonMark.TableHeader())
@@ -343,36 +343,36 @@ _mast_to_node(::MarkdownAST.TableBody, m) = CommonMark.Node(CommonMark.TableBody
 _mast_to_node(::MarkdownAST.TableRow, m) = CommonMark.Node(CommonMark.TableRow())
 
 function _mast_to_node(e::MarkdownAST.TableCell, m)
-    CommonMark.Node(CommonMark.TableCell(e.align, e.header, e.column, 1, 1))
+    return CommonMark.Node(CommonMark.TableCell(e.align, e.header, e.column, 1, 1))
 end
 
 # Extensions with CommonMark equivalents
 function _mast_to_node(e::MarkdownAST.Admonition, m)
-    CommonMark.Node(CommonMark.Admonition(e.category, e.title))
+    return CommonMark.Node(CommonMark.Admonition(e.category, e.title))
 end
 
 function _mast_to_node(e::MarkdownAST.InlineMath, m)
     n = CommonMark.Node(CommonMark.Math())
     n.literal = e.math
-    n
+    return n
 end
 
 function _mast_to_node(e::MarkdownAST.DisplayMath, m)
     n = CommonMark.Node(CommonMark.DisplayMath())
     n.literal = e.math
-    n
+    return n
 end
 
 function _mast_to_node(e::MarkdownAST.FootnoteDefinition, m)
-    CommonMark.Node(CommonMark.FootnoteDefinition(e.id))
+    return CommonMark.Node(CommonMark.FootnoteDefinition(e.id))
 end
 
 function _mast_to_node(e::MarkdownAST.FootnoteLink, m)
-    CommonMark.Node(CommonMark.FootnoteLink, e.id)
+    return CommonMark.Node(CommonMark.FootnoteLink, e.id)
 end
 
 function _mast_to_node(e::MarkdownAST.JuliaValue, m)
-    CommonMark.Node(CommonMark.JuliaValue(e.ex, e.ref))
+    return CommonMark.Node(CommonMark.JuliaValue(e.ex, e.ref))
 end
 
 # Fallback: warn and skip

--- a/ext/CommonMarkMarkdownExt.jl
+++ b/ext/CommonMarkMarkdownExt.jl
@@ -13,7 +13,7 @@ end
 # Flatten nested Markdown.MD and merge metadata (outer takes precedence)
 function flatten_md(md::Markdown.MD)
     content = Any[]
-    meta = Dict{Symbol,Any}()
+    meta = Dict{Symbol, Any}()
     for (k, v) in md.meta
         meta[k] = v
     end
@@ -152,7 +152,7 @@ function from_stdlib_block(elem::Markdown.Table)
     if length(rows) > 1
         body = CommonMark.Node(CommonMark.TableBody())
         CommonMark.append_child(table, body)
-        for i = 2:length(rows)
+        for i in 2:length(rows)
             row = table_row_from_stdlib(rows[i], spec, false)
             CommonMark.append_child(body, row)
         end
@@ -207,6 +207,7 @@ function process_inlines!(parent::CommonMark.Node, content)
         child = from_stdlib_inline(elem)
         !isnothing(child) && CommonMark.append_child(parent, child)
     end
+    return
 end
 
 function from_stdlib_inline(s::AbstractString)
@@ -283,7 +284,7 @@ end
 # Convert LazyCommonMarkDoc to Markdown.MD via MarkdownAST intermediate
 function Base.convert(::Type{Markdown.MD}, doc::CommonMark.LazyCommonMarkDoc)
     mast = CommonMark.to_mast(doc)  # Calls MarkdownAST ext
-    convert(Markdown.MD, mast)
+    return convert(Markdown.MD, mast)
 end
 
 end # module

--- a/justfile
+++ b/justfile
@@ -1,10 +1,12 @@
 update:
     julia --project=. -e 'import Pkg; Pkg.update()'
     julia --project=.ci -e 'import Pkg; Pkg.update()'
-    julia --project=.format -e 'import Pkg; Pkg.update()'
 
-format:
-    julia --project=.format .format/format.jl
+fmt:
+    runic --inplace .
+
+fmt-check:
+    runic --check .
 
 changelog:
     julia --project=.ci .ci/changelog.jl

--- a/src/CommonMark.jl
+++ b/src/CommonMark.jl
@@ -65,18 +65,18 @@ export AdmonitionRule,
     eval(
         Meta.parse(
             """
-    public Node,
-        append_child, prepend_child, insert_after, insert_before, unlink, isnull, text,
-        Document, Paragraph, Heading, BlockQuote, List, Item, CodeBlock, HtmlBlock, ThematicBreak,
-        Text, SoftBreak, LineBreak, Code, Emph, Strong, Link, Image, HtmlInline,
-        Table, TableHeader, TableBody, TableFoot, TableRow, TableCell,
-        DisplayMath, Admonition, FencedDiv, FootnoteDefinition, LaTeXBlock, TypstBlock,
-        Math, Strikethrough, Mark, Subscript, Superscript, LaTeXInline, TypstInline,
-        GitHubAlert, TaskItem, FootnoteLink, Citation,
-        ReferenceLink, ReferenceImage, ReferenceDefinition, UnresolvedReference,
-        Shortcode, ShortcodeBlock, ShortcodeContext,
-        DefinitionList, DefinitionTerm, DefinitionDescription
-""",
+                public Node,
+                    append_child, prepend_child, insert_after, insert_before, unlink, isnull, text,
+                    Document, Paragraph, Heading, BlockQuote, List, Item, CodeBlock, HtmlBlock, ThematicBreak,
+                    Text, SoftBreak, LineBreak, Code, Emph, Strong, Link, Image, HtmlInline,
+                    Table, TableHeader, TableBody, TableFoot, TableRow, TableCell,
+                    DisplayMath, Admonition, FencedDiv, FootnoteDefinition, LaTeXBlock, TypstBlock,
+                    Math, Strikethrough, Mark, Subscript, Superscript, LaTeXInline, TypstInline,
+                    GitHubAlert, TaskItem, FootnoteLink, Citation,
+                    ReferenceLink, ReferenceImage, ReferenceDefinition, UnresolvedReference,
+                    Shortcode, ShortcodeBlock, ShortcodeContext,
+                    DefinitionList, DefinitionTerm, DefinitionDescription
+            """,
         ),
     )
 end

--- a/src/ExtensionLoader.jl
+++ b/src/ExtensionLoader.jl
@@ -6,7 +6,7 @@ import ..CommonMark
 function ext_entry(uuid, name)
     pkg = Base.PkgId(Base.UUID(uuid), name)
     file = "CommonMark$(name)Ext.jl"
-    pkg => (read(joinpath(@__DIR__, "..", "ext", file), String), file, Ref(false))
+    return pkg => (read(joinpath(@__DIR__, "..", "ext", file), String), file, Ref(false))
 end
 
 const EXTENSIONS = Dict(
@@ -20,7 +20,7 @@ function load_ext(pkg::Base.PkgId)
     loaded[] && return
     loaded[] = true
     mod = Module(Symbol(:CommonMarkExtensionLoader_, pkg.name))
-    Base.invokelatest() do
+    return Base.invokelatest() do
         Core.eval(mod, :(const CommonMark = $CommonMark))
         Core.eval(mod, :(const $(Symbol(pkg.name)) = $(Base.loaded_modules[pkg])))
         include_string(mod, extcode, extfile)
@@ -34,7 +34,7 @@ function __init__()
             load_ext(pkg)
         end
     end
-    push!(Base.package_callbacks, load_ext)
+    return push!(Base.package_callbacks, load_ext)
 end
 
 end

--- a/src/ast.jl
+++ b/src/ast.jl
@@ -4,7 +4,7 @@ abstract type AbstractInline <: AbstractContainer end
 
 is_container(::AbstractContainer) = false
 
-const SourcePos = NTuple{2,NTuple{2,Int}}
+const SourcePos = NTuple{2, NTuple{2, Int}}
 
 mutable struct Node
     t::AbstractContainer
@@ -18,8 +18,8 @@ mutable struct Node
     last_line_checked::Bool
     is_open::Bool
     literal::String
-    literal_buffer::Union{Nothing,IOBuffer}
-    meta::Union{Nothing,Dict{String,Any}}
+    literal_buffer::Union{Nothing, IOBuffer}
+    meta::Union{Nothing, Dict{String, Any}}
 
     Node() = new()
 
@@ -44,7 +44,7 @@ end
 
 """Finalize literal from buffer, converting IOBuffer to String."""
 function finalize_literal!(node::Node)
-    if node.literal_buffer !== nothing
+    return if node.literal_buffer !== nothing
         node.literal = String(take!(node.literal_buffer))
         node.literal_buffer = nothing
     end
@@ -59,18 +59,18 @@ hasmeta(node::Node, key) = !isnothing(node.meta) && haskey(node.meta, key)
 
 """Set meta value, initializing dict if needed."""
 function setmeta!(node::Node, key, value)
-    isnothing(node.meta) && (node.meta = Dict{String,Any}())
-    node.meta[key] = value
+    isnothing(node.meta) && (node.meta = Dict{String, Any}())
+    return node.meta[key] = value
 end
 
 """Merge dict into meta, initializing if needed."""
 function mergemeta!(node::Node, d::AbstractDict)
-    isnothing(node.meta) && (node.meta = Dict{String,Any}())
-    merge!(node.meta, d)
+    isnothing(node.meta) && (node.meta = Dict{String, Any}())
+    return merge!(node.meta, d)
 end
 
 function copy_tree(func::Function, root::Node)
-    lookup = Dict{Node,Node}()
+    lookup = Dict{Node, Node}()
     for (old, enter) in root
         if enter
             lookup[old] = Node()
@@ -117,7 +117,7 @@ isnull(node::Node) = node === NULL_NODE
 
 Compare two container types for equality, checking type and all fields.
 """
-container_equal(a::T, b::T) where {T<:AbstractContainer} =
+container_equal(a::T, b::T) where {T <: AbstractContainer} =
     all(getfield(a, f) == getfield(b, f) for f in fieldnames(T))
 container_equal(::AbstractContainer, ::AbstractContainer) = false
 
@@ -139,7 +139,7 @@ function ast_equal(a::Node, b::Node)
         ast_equal(ca, cb) || return false
         ca, cb = ca.nxt, cb.nxt
     end
-    isnull(ca) && isnull(cb)
+    return isnull(ca) && isnull(cb)
 end
 
 is_container(node::Node) = is_container(node.t)::Bool
@@ -179,7 +179,7 @@ Add `child` as the last child of `parent`. Unlinks `child` from any previous loc
 function append_child(node::Node, child::Node)
     unlink(child)
     child.parent = node
-    if !isnull(node.last_child)
+    return if !isnull(node.last_child)
         node.last_child.nxt = child
         child.prv = node.last_child
         node.last_child = child
@@ -197,7 +197,7 @@ Add `child` as the first child of `parent`. Unlinks `child` from any previous lo
 function prepend_child(node::Node, child::Node)
     unlink(child)
     child.parent = node
-    if !isnull(node.first_child)
+    return if !isnull(node.first_child)
         node.first_child.prv = child
         child.nxt = node.first_child
         node.first_child = child
@@ -227,7 +227,7 @@ function unlink(node::Node)
 
     node.parent = NULL_NODE
     node.nxt = NULL_NODE
-    node.prv = NULL_NODE
+    return node.prv = NULL_NODE
 end
 
 """
@@ -244,7 +244,7 @@ function insert_after(node::Node, sibling::Node)
     sibling.prv = node
     node.nxt = sibling
     sibling.parent = node.parent
-    if isnull(sibling.nxt) && !isnull(sibling.parent)
+    return if isnull(sibling.nxt) && !isnull(sibling.parent)
         sibling.parent.last_child = sibling
     end
 end
@@ -263,7 +263,7 @@ function insert_before(node::Node, sibling::Node)
     sibling.nxt = node
     node.prv = sibling
     sibling.parent = node.parent
-    if isnull(sibling.prv) && !isnull(sibling.parent)
+    return if isnull(sibling.prv) && !isnull(sibling.parent)
         sibling.parent.first_child = sibling
     end
 end
@@ -277,5 +277,5 @@ function _build(t::AbstractContainer, children)
     for child in children
         append_child(node, _to_node(child))
     end
-    node
+    return node
 end

--- a/src/extensions/admonitions.jl
+++ b/src/extensions/admonitions.jl
@@ -12,13 +12,13 @@ can_contain(::Admonition, t) = !(t isa Item)
 finalize(::Admonition, parser::Parser, node::Node) = nothing
 
 function Node(
-    ::Type{Admonition},
-    category::AbstractString,
-    title::AbstractString,
-    children...,
-)
+        ::Type{Admonition},
+        category::AbstractString,
+        title::AbstractString,
+        children...,
+    )
     a = Admonition(category, title)
-    _build(a, children)
+    return _build(a, children)
 end
 
 function continue_(::Admonition, parser::Parser, ::Any)
@@ -71,7 +71,7 @@ block_rule(::AdmonitionRule) = Rule(parse_admonition, 0.5, "!")
 #
 
 function write_html(a::Admonition, rend, node, enter)
-    if enter
+    return if enter
         tag(rend, "div", attributes(rend, node, ["class" => "admonition $(a.category)"]))
         tag(rend, "p", ["class" => "admonition-title"])
         print(rend.buffer, a.title)
@@ -83,7 +83,7 @@ end
 
 # Requires tcolorbox package and custom newtcolorbox definitions.
 function write_latex(a::Admonition, w, node, enter)
-    if enter
+    return if enter
         cr(w)
         literal(w, "\\begin{admonition@$(a.category)}{$(a.title)}\n")
     else
@@ -93,7 +93,7 @@ function write_latex(a::Admonition, w, node, enter)
 end
 
 function write_typst(a::Admonition, w, node, enter)
-    if enter
+    return if enter
         styles = Dict(
             "danger" => "#dc2626",
             "warning" => "#facc15",
@@ -126,7 +126,7 @@ function write_term(a::Admonition, rend, node, enter)
         "tip" => crayon"green bold",
     )
     style = get(styles, a.category, crayon"default bold")
-    if enter
+    return if enter
         header = rpad("┌ $(a.title) ", available_columns(rend), "─")
         print_margin(rend)
         print_literal(rend, style, header, inv(style), "\n")
@@ -151,7 +151,7 @@ function write_term(a::Admonition, rend, node, enter)
 end
 
 function write_markdown(a::Admonition, w, node, ent)
-    if ent
+    return if ent
         push_margin!(w, "    ")
         literal(w, "!!! ", a.category)
         if lowercase(a.title) != lowercase(a.category)
@@ -168,7 +168,7 @@ function write_markdown(a::Admonition, w, node, ent)
 end
 
 function write_json(a::Admonition, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else

--- a/src/extensions/attributes.jl
+++ b/src/extensions/attributes.jl
@@ -52,8 +52,7 @@ end
 
 block_rule(::AttributeRule) = Rule(parse_block_attributes, 1, "{")
 
-inline_rule(rule::AttributeRule) =
-    Rule(1, "{") do parser, block
+inline_rule(rule::AttributeRule) = Rule(1, "{") do parser, block
     isnull(block.first_child) && return false # Can't have inline attribute as first in block.
     dict, literal = try_parse_attributes(parser)
     dict === nothing && return false
@@ -155,16 +154,14 @@ function try_parse_attributes(parser::AbstractParser)
     end
 end
 
-block_modifier(::AttributeRule) =
-    Rule(1) do parser, node
+block_modifier(::AttributeRule) = Rule(1) do parser, node
     if node.t isa Attributes && !isnull(node.nxt)
         node.nxt.t isa Attributes || (node.nxt.meta = node.t.dict)
     end
     return nothing
 end
 
-inline_modifier(rule::AttributeRule) =
-    Rule(1) do parser, block
+inline_modifier(rule::AttributeRule) = Rule(1) do parser, block
     while !isempty(rule.nodes)
         node = pop!(rule.nodes)
         if !isnull(node.prv) && !(node.prv.t isa Attributes)

--- a/src/extensions/attributes.jl
+++ b/src/extensions/attributes.jl
@@ -22,7 +22,7 @@ struct AttributeRule
 end
 
 struct Attributes <: AbstractBlock
-    dict::Dict{String,Any}
+    dict::Dict{String, Any}
     block::Bool
 end
 
@@ -35,7 +35,7 @@ can_contain(::Attributes, t) = false
 function parse_block_attributes(parser::Parser, container::Node)
     # Block attributes mustn't appear directly after another attribute block.
     if !parser.indented &&
-       (isnull(container.last_child) || !(container.last_child.t isa Attributes))
+            (isnull(container.last_child) || !(container.last_child.t isa Attributes))
         dict, literal = try_parse_attributes(parser)
         if dict !== nothing
             advance_next_nonspace(parser)
@@ -54,15 +54,15 @@ block_rule(::AttributeRule) = Rule(parse_block_attributes, 1, "{")
 
 inline_rule(rule::AttributeRule) =
     Rule(1, "{") do parser, block
-        isnull(block.first_child) && return false # Can't have inline attribute as first in block.
-        dict, literal = try_parse_attributes(parser)
-        dict === nothing && return false
-        node = Node(Attributes(dict, false))
-        node.literal = literal
-        push!(rule.nodes, node)
-        append_child(block, node)
-        return true
-    end
+    isnull(block.first_child) && return false # Can't have inline attribute as first in block.
+    dict, literal = try_parse_attributes(parser)
+    dict === nothing && return false
+    node = Node(Attributes(dict, false))
+    node.literal = literal
+    push!(rule.nodes, node)
+    append_child(block, node)
+    return true
+end
 
 function try_parse_attributes(parser::AbstractParser)
     start_mark = pos = position(parser)
@@ -72,7 +72,7 @@ function try_parse_attributes(parser::AbstractParser)
     end
     @assert read(parser, Char) === '{'
     valid = false
-    dict = Dict{String,Any}()
+    dict = Dict{String, Any}()
     key = ""
     while !eof(parser)
         pos = position(parser)
@@ -157,21 +157,21 @@ end
 
 block_modifier(::AttributeRule) =
     Rule(1) do parser, node
-        if node.t isa Attributes && !isnull(node.nxt)
-            node.nxt.t isa Attributes || (node.nxt.meta = node.t.dict)
-        end
-        return nothing
+    if node.t isa Attributes && !isnull(node.nxt)
+        node.nxt.t isa Attributes || (node.nxt.meta = node.t.dict)
     end
+    return nothing
+end
 
 inline_modifier(rule::AttributeRule) =
     Rule(1) do parser, block
-        while !isempty(rule.nodes)
-            node = pop!(rule.nodes)
-            if !isnull(node.prv) && !(node.prv.t isa Attributes)
-                node.prv.meta = node.t.dict
-            end
+    while !isempty(rule.nodes)
+        node = pop!(rule.nodes)
+        if !isnull(node.prv) && !(node.prv.t isa Attributes)
+            node.prv.meta = node.t.dict
         end
     end
+end
 
 # Writers.
 
@@ -181,7 +181,7 @@ write_typst(::Attributes, w, n, ent) = nothing
 write_term(::Attributes, w, n, ent) = nothing
 
 function write_markdown(at::Attributes, w, n, ent)
-    if ent
+    return if ent
         at.block && print_margin(w)
         literal(w, n.literal, at.block ? "\n" : "")
     end

--- a/src/extensions/autoidentifiers.jl
+++ b/src/extensions/autoidentifiers.jl
@@ -20,8 +20,7 @@ end
 
 reset_rule!(r::AutoIdentifierRule) = (empty!(r.refs); nothing)
 
-block_modifier(rule::AutoIdentifierRule) =
-    Rule(100) do parser, block
+block_modifier(rule::AutoIdentifierRule) = Rule(100) do parser, block
     # Add heading IDs to those without any preset by AttributeRule.
     if block.t isa Heading && !hasmeta(block, "id")
         setmeta!(block, "id", slugify(block.literal))

--- a/src/extensions/autoidentifiers.jl
+++ b/src/extensions/autoidentifiers.jl
@@ -14,7 +14,7 @@ are preserved.
 ```
 """
 struct AutoIdentifierRule
-    refs::IdDict{Node,Dict{String,Int}}
+    refs::IdDict{Node, Dict{String, Int}}
     AutoIdentifierRule(refs = IdDict()) = new(refs)
 end
 
@@ -22,19 +22,19 @@ reset_rule!(r::AutoIdentifierRule) = (empty!(r.refs); nothing)
 
 block_modifier(rule::AutoIdentifierRule) =
     Rule(100) do parser, block
-        # Add heading IDs to those without any preset by AttributeRule.
-        if block.t isa Heading && !hasmeta(block, "id")
-            setmeta!(block, "id", slugify(block.literal))
-        end
-        # Then make sure all IDs for the current AutoIdentifierRule are unique using a counter.
-        if hasmeta(block, "id")
-            counter = get!(() -> Dict{String,Int}(), rule.refs, parser.doc)
-            id = getmeta(block, "id", "")
-            n = counter[id] = get!(counter, id, 0) + 1
-            setmeta!(block, "id", n == 1 ? id : "$id-$(n - 1)")
-        end
-        return nothing
+    # Add heading IDs to those without any preset by AttributeRule.
+    if block.t isa Heading && !hasmeta(block, "id")
+        setmeta!(block, "id", slugify(block.literal))
     end
+    # Then make sure all IDs for the current AutoIdentifierRule are unique using a counter.
+    if hasmeta(block, "id")
+        counter = get!(() -> Dict{String, Int}(), rule.refs, parser.doc)
+        id = getmeta(block, "id", "")
+        n = counter[id] = get!(counter, id, 0) + 1
+        setmeta!(block, "id", n == 1 ? id : "$id-$(n - 1)")
+    end
+    return nothing
+end
 
 # Modelled on pandoc's algorithm.
 function slugify(str::AbstractString)

--- a/src/extensions/citations.jl
+++ b/src/extensions/citations.jl
@@ -7,7 +7,7 @@ end
 function Node(::Type{Citation}, id::AbstractString; brackets::Bool = false)
     node = Node(Citation(id, brackets))
     node.literal = "@$id"
-    node
+    return node
 end
 
 struct CitationBracket <: AbstractBlock end
@@ -33,66 +33,66 @@ end
 
 inline_rule(rule::CitationRule) =
     Rule(1, "@") do parser, block
-        m = consume(
-            parser,
-            match(r"@[_\w\d](?:[_\w\d]|[:#$%&\-\+\?\<\>~/](?=[_\w\d]))*", parser),
-        )
-        m === nothing && return false
-        bs = parser.brackets
-        opener = bs !== nothing && is_bracket(bs.node, "[")
-        citation = Node(Citation(chop(m.match; head = 1, tail = 0), opener))
-        citation.literal = m.match
-        append_child(block, citation)
-        push!(rule.cites, citation)
-        return true
-    end
+    m = consume(
+        parser,
+        match(r"@[_\w\d](?:[_\w\d]|[:#$%&\-\+\?\<\>~/](?=[_\w\d]))*", parser),
+    )
+    m === nothing && return false
+    bs = parser.brackets
+    opener = bs !== nothing && is_bracket(bs.node, "[")
+    citation = Node(Citation(chop(m.match; head = 1, tail = 0), opener))
+    citation.literal = m.match
+    append_child(block, citation)
+    push!(rule.cites, citation)
+    return true
+end
 
 is_bracket(n::Node, c) = n.literal == c && n.t isa Text
 
 inline_modifier(rule::CitationRule) =
     Rule(1) do parser, block
-        openers = Set{Node}()
-        closers = Set{Node}()
-        while !isempty(rule.cites)
-            cite = pop!(rule.cites)
-            if cite.t.brackets
-                opener = closer = cite
-                while !isnull(opener.prv)
-                    opener = opener.prv
-                    opener in openers && @goto SKIP
-                    opener.t isa Citation && break
-                    if is_bracket(opener, "[")
-                        opener.t = CitationBracket()
-                        push!(openers, opener)
-                        break
-                    end
+    openers = Set{Node}()
+    closers = Set{Node}()
+    while !isempty(rule.cites)
+        cite = pop!(rule.cites)
+        if cite.t.brackets
+            opener = closer = cite
+            while !isnull(opener.prv)
+                opener = opener.prv
+                opener in openers && @goto SKIP
+                opener.t isa Citation && break
+                if is_bracket(opener, "[")
+                    opener.t = CitationBracket()
+                    push!(openers, opener)
+                    break
                 end
-                while !isnull(closer.nxt)
-                    closer = closer.nxt
-                    closer in closers && @goto SKIP
-                    closer.t isa Citation && break
-                    if is_bracket(closer, "]")
-                        closer.t = CitationBracket()
-                        push!(closers, closer)
-                        break
-                    end
-                end
-                @label SKIP
             end
+            while !isnull(closer.nxt)
+                closer = closer.nxt
+                closer in closers && @goto SKIP
+                closer.t isa Citation && break
+                if is_bracket(closer, "]")
+                    closer.t = CitationBracket()
+                    push!(closers, closer)
+                    break
+                end
+            end
+            @label SKIP
         end
     end
+end
 
 struct References <: AbstractBlock end
 
 block_modifier(::CitationRule) =
     Rule(10) do parser, b
-        if !isnull(b.parent) && b.parent.t isa Document
-            if hasmeta(b, "id") && getmeta(b, "id", "") == "refs"
-                insert_after(b, Node(References()))
-            end
+    if !isnull(b.parent) && b.parent.t isa Document
+        if hasmeta(b, "id") && getmeta(b, "id", "") == "refs"
+            insert_after(b, Node(References()))
         end
-        return nothing
     end
+    return nothing
+end
 
 # Writers. TODO: implement real CSL for citation styling.
 
@@ -115,7 +115,7 @@ function write_html(c::Citation, w, n, ent)
     linked && tag(w, "a", ["href" => "#ref-$(c.id)"])
     literal(w, CSL.author_year(w.env, c.id))
     linked && tag(w, "/a")
-    tag(w, "/span")
+    return tag(w, "/span")
 end
 
 function write_latex(c::Citation, w, n, ent)
@@ -148,7 +148,7 @@ function write_term(c::Citation, w, n, ent)
     push_inline!(w, style)
     print_literal(w, CSL.author_year(w.env, c.id))
     pop_inline!(w)
-    print_literal(w, inv(style))
+    return print_literal(w, inv(style))
 end
 
 write_html(::CitationBracket, w, n, ent) = literal(w, n.literal == "[" ? "(" : ")")
@@ -168,7 +168,7 @@ function write_json(c::Citation, ctx, node, enter)
         "citationNoteNum" => 0,
         "citationHash" => 0,
     )
-    push_element!(
+    return push_element!(
         ctx,
         json_el(ctx, "Cite", Any[Any[citation], text_to_inlines(ctx, "@" * c.id)]),
     )
@@ -184,7 +184,7 @@ write_typst(::References, w, n, ent) = nothing # unsupported
 
 function write_references(f, writer)
     ast = build_references(get(writer.env, "references", nothing))
-    f(writer, ast)
+    return f(writer, ast)
 end
 
 struct ReferenceList <: AbstractBlock end
@@ -242,71 +242,71 @@ end
 
 module CSL
 
-rget(f, col, key, keys...) = contains(col, key) ? rget(f, col[key], keys...) : f()
-rget(f, col, key) = tryget(f, col, key)
-tryget(f, d, key) = contains(d, key) ? d[key] : f()
-contains(d::AbstractDict, key) = haskey(d, key)
-contains(v::AbstractVector, index) = index in keys(v)
-contains(others...) = false
+    rget(f, col, key, keys...) = contains(col, key) ? rget(f, col[key], keys...) : f()
+    rget(f, col, key) = tryget(f, col, key)
+    tryget(f, d, key) = contains(d, key) ? d[key] : f()
+    contains(d::AbstractDict, key) = haskey(d, key)
+    contains(v::AbstractVector, index) = index in keys(v)
+    contains(others...) = false
 
-year(item) = rget(() -> nothing, item, "issued", "date-parts", 1, 1)
-authors(item) =
-    filter(d -> d isa AbstractDict && haskey(d, "family"), rget(() -> [], item, "author"))
-title(item) = rget(() -> nothing, item, "title")
+    year(item) = rget(() -> nothing, item, "issued", "date-parts", 1, 1)
+    authors(item) =
+        filter(d -> d isa AbstractDict && haskey(d, "family"), rget(() -> [], item, "author"))
+    title(item) = rget(() -> nothing, item, "title")
 
-function year(env::AbstractDict, id::AbstractString)
-    y = year(get_item(env, id))
-    return y === nothing ? "@$id" : y
-end
-
-author_short(item) = get(() -> get(item, "given", ""), item, "family")
-
-function authors_short(item)
-    names = sort(authors(item); by = author_short)
-    n = length(names)
-    n === 0 && return "Unknown"
-    1 ≤ n ≤ 2 && return join(author_short.(names), " and ")
-    n === 3 && return join(author_short.(names), ", ", ", and ")
-    return author_short(names[1]) * " et al."
-end
-
-function author_long(item, first)
-    family = get(item, "family", "")
-    given = get(item, "given", "")
-    given == "" && return family
-    family == "" && return given
-    return first ? "$family, $given" : "$given $family"
-end
-
-function authors_long(item)
-    names = sort(authors(item); by = author_short)
-    return join((author_long(a, n == 1) for (n, a) in enumerate(names)), ", ", ", and ")
-end
-
-mapbib(items::AbstractVector) =
-    Dict{String,Dict}(item["id"] => item for item in items if haskey(item, "id"))
-
-function get_item(env, id)
-    if haskey(env, "references")
-        refs = get!(() -> mapbib(env["references"]), env, "ref-map")
-        haskey(refs, id) && return refs[id]
+    function year(env::AbstractDict, id::AbstractString)
+        y = year(get_item(env, id))
+        return y === nothing ? "@$id" : y
     end
-    return nothing
-end
 
-function author_year(env::AbstractDict, id::AbstractString)
-    item = get_item(env, id)
-    return item === nothing ? "@$id" : author_year(item)
-end
-author_year(item) = "$(authors_short(item)) $(year(item))"
+    author_short(item) = get(() -> get(item, "given", ""), item, "family")
 
-publisher(d) = _publisher(get(d, "publisher-place", nothing), get(d, "publisher", nothing))
-_publisher(place, name) = "$place: $name"
-_publisher(::Nothing, name::AbstractString) = name
-_publisher(place::AbstractString, ::Nothing) = place
-_publisher(::Nothing, ::Nothing) = nothing
+    function authors_short(item)
+        names = sort(authors(item); by = author_short)
+        n = length(names)
+        n === 0 && return "Unknown"
+        1 ≤ n ≤ 2 && return join(author_short.(names), " and ")
+        n === 3 && return join(author_short.(names), ", ", ", and ")
+        return author_short(names[1]) * " et al."
+    end
 
-url(d) = get(d, "URL", nothing)
-doi(d) = get(d, "DOI", nothing)
+    function author_long(item, first)
+        family = get(item, "family", "")
+        given = get(item, "given", "")
+        given == "" && return family
+        family == "" && return given
+        return first ? "$family, $given" : "$given $family"
+    end
+
+    function authors_long(item)
+        names = sort(authors(item); by = author_short)
+        return join((author_long(a, n == 1) for (n, a) in enumerate(names)), ", ", ", and ")
+    end
+
+    mapbib(items::AbstractVector) =
+        Dict{String, Dict}(item["id"] => item for item in items if haskey(item, "id"))
+
+    function get_item(env, id)
+        if haskey(env, "references")
+            refs = get!(() -> mapbib(env["references"]), env, "ref-map")
+            haskey(refs, id) && return refs[id]
+        end
+        return nothing
+    end
+
+    function author_year(env::AbstractDict, id::AbstractString)
+        item = get_item(env, id)
+        return item === nothing ? "@$id" : author_year(item)
+    end
+    author_year(item) = "$(authors_short(item)) $(year(item))"
+
+    publisher(d) = _publisher(get(d, "publisher-place", nothing), get(d, "publisher", nothing))
+    _publisher(place, name) = "$place: $name"
+    _publisher(::Nothing, name::AbstractString) = name
+    _publisher(place::AbstractString, ::Nothing) = place
+    _publisher(::Nothing, ::Nothing) = nothing
+
+    url(d) = get(d, "URL", nothing)
+    doi(d) = get(d, "DOI", nothing)
 
 end

--- a/src/extensions/citations.jl
+++ b/src/extensions/citations.jl
@@ -31,8 +31,7 @@ struct CitationRule
     CitationRule() = new([])
 end
 
-inline_rule(rule::CitationRule) =
-    Rule(1, "@") do parser, block
+inline_rule(rule::CitationRule) = Rule(1, "@") do parser, block
     m = consume(
         parser,
         match(r"@[_\w\d](?:[_\w\d]|[:#$%&\-\+\?\<\>~/](?=[_\w\d]))*", parser),
@@ -49,8 +48,7 @@ end
 
 is_bracket(n::Node, c) = n.literal == c && n.t isa Text
 
-inline_modifier(rule::CitationRule) =
-    Rule(1) do parser, block
+inline_modifier(rule::CitationRule) = Rule(1) do parser, block
     openers = Set{Node}()
     closers = Set{Node}()
     while !isempty(rule.cites)
@@ -84,8 +82,7 @@ end
 
 struct References <: AbstractBlock end
 
-block_modifier(::CitationRule) =
-    Rule(10) do parser, b
+block_modifier(::CitationRule) = Rule(10) do parser, b
     if !isnull(b.parent) && b.parent.t isa Document
         if hasmeta(b, "id") && getmeta(b, "id", "") == "refs"
             insert_after(b, Node(References()))

--- a/src/extensions/definitionlists.jl
+++ b/src/extensions/definitionlists.jl
@@ -97,7 +97,7 @@ finalize(::DefinitionDescription, ::Parser, ::Node) = nothing
 function Node(::Type{DefinitionList}, children...; tight::Bool = true)
     dl = DefinitionList()
     dl.tight = tight
-    _build(dl, children)
+    return _build(dl, children)
 end
 
 Node(::Type{DefinitionTerm}, children...) = _build(DefinitionTerm(), children)
@@ -223,7 +223,7 @@ block_rule(::DefinitionListRule) = Rule(parse_definition, 0.5, ":")
 # HTML
 
 function write_html(::DefinitionList, rend, node, enter)
-    if enter
+    return if enter
         cr(rend)
         tag(rend, "dl", attributes(rend, node))
         cr(rend)
@@ -235,7 +235,7 @@ function write_html(::DefinitionList, rend, node, enter)
 end
 
 function write_html(::DefinitionTerm, rend, node, enter)
-    if enter
+    return if enter
         tag(rend, "dt", attributes(rend, node))
     else
         tag(rend, "/dt")
@@ -244,7 +244,7 @@ function write_html(::DefinitionTerm, rend, node, enter)
 end
 
 function write_html(::DefinitionDescription, rend, node, enter)
-    if enter
+    return if enter
         tag(rend, "dd", attributes(rend, node))
         cr(rend)
     else
@@ -266,11 +266,11 @@ function write_latex(::DefinitionList, w, node, enter)
     else
         literal(w, "\\end{description}")
     end
-    cr(w)
+    return cr(w)
 end
 
 function write_latex(::DefinitionTerm, w, node, enter)
-    if enter
+    return if enter
         literal(w, "\\item[")
     else
         literal(w, "]")
@@ -280,20 +280,20 @@ end
 
 function write_latex(::DefinitionDescription, w, node, enter)
     # Content rendered by children, no explicit wrapper
-    nothing
+    return nothing
 end
 
 # Typst
 
 function write_typst(::DefinitionList, w, node, enter)
-    if !enter
+    return if !enter
         cr(w)
         linebreak(w, node)
     end
 end
 
 function write_typst(::DefinitionTerm, w, node, enter)
-    if enter
+    return if enter
         print_margin(w)
         literal(w, "/ ")
     else
@@ -316,7 +316,7 @@ function write_typst(::DefinitionDescription, w, node, enter)
     use_block = _typst_use_block(node)
     is_first = isnull(node.prv) || node.prv.t isa DefinitionTerm
     is_last = isnull(node.nxt) || node.nxt.t isa DefinitionTerm
-    if enter
+    return if enter
         if use_block && is_first
             literal(w, "#block[\n")
         end
@@ -337,14 +337,14 @@ end
 # Markdown (roundtrip)
 
 function write_markdown(::DefinitionList, w, node, enter)
-    if !enter
+    return if !enter
         cr(w)
         linebreak(w, node)
     end
 end
 
 function write_markdown(::DefinitionTerm, w, node, enter)
-    if enter
+    return if enter
         print_margin(w)
     else
         cr(w)
@@ -352,7 +352,7 @@ function write_markdown(::DefinitionTerm, w, node, enter)
 end
 
 function write_markdown(::DefinitionDescription, w, node, enter)
-    if enter
+    return if enter
         push_margin!(w, 1, ":   ", " "^4)
     else
         pop_margin!(w)
@@ -367,7 +367,7 @@ end
 # Terminal
 
 function write_term(::DefinitionList, rend, node, enter)
-    if !enter && !isnull(node.nxt)
+    return if !enter && !isnull(node.nxt)
         print_margin(rend)
         print_literal(rend, "\n")
     end
@@ -375,7 +375,7 @@ end
 
 function write_term(::DefinitionTerm, rend, node, enter)
     style = crayon"bold"
-    if enter
+    return if enter
         rend.format.wrap = 0
         print_margin(rend)
         print_literal(rend, style)
@@ -389,7 +389,7 @@ function write_term(::DefinitionTerm, rend, node, enter)
 end
 
 function write_term(::DefinitionDescription, rend, node, enter)
-    if enter
+    return if enter
         push_margin!(rend, "  ", crayon"")
     else
         pop_margin!(rend)
@@ -399,7 +399,7 @@ end
 # JSON (Pandoc AST)
 
 function write_json(::DefinitionList, ctx, node, enter)
-    if enter
+    return if enter
         items = Any[]
         push_container!(ctx, items)
     else
@@ -420,7 +420,7 @@ function write_json(::DefinitionList, ctx, node, enter)
 end
 
 function write_json(::DefinitionTerm, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -430,7 +430,7 @@ function write_json(::DefinitionTerm, ctx, node, enter)
 end
 
 function write_json(::DefinitionDescription, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else

--- a/src/extensions/docstrings.jl
+++ b/src/extensions/docstrings.jl
@@ -31,7 +31,7 @@ function Base.getproperty(doc::LazyCommonMarkDoc, s::Symbol)
         @assert length(docstrs) == 1 "meta only valid for single docstr"
         return docstrs[1].data
     end
-    getfield(doc, s)
+    return getfield(doc, s)
 end
 
 function _parse_doc(doc::LazyCommonMarkDoc)
@@ -48,7 +48,7 @@ function _parse_doc(doc::LazyCommonMarkDoc)
             end
 
             # Parse with source location from docstring metadata
-            kws = Dict{Symbol,Any}()
+            kws = Dict{Symbol, Any}()
             haskey(docstr.data, :path) && (kws[:source] = docstr.data[:path])
             haskey(docstr.data, :linenumber) && (kws[:line] = docstr.data[:linenumber])
             haskey(docstr.data, :module) && (kws[:module] = docstr.data[:module])
@@ -62,7 +62,7 @@ function _parse_doc(doc::LazyCommonMarkDoc)
         end
         doc.parsed = result
     end
-    doc.parsed
+    return doc.parsed
 end
 
 Base.show(io::IO, ::MIME"text/plain", doc::LazyCommonMarkDoc) =
@@ -74,7 +74,7 @@ function Docs.catdoc(docs::LazyCommonMarkDoc...)
     for doc in docs
         append!(all_docstrs, doc.docstrs)
     end
-    LazyCommonMarkDoc(all_docstrs, parser)
+    return LazyCommonMarkDoc(all_docstrs, parser)
 end
 
 """
@@ -93,7 +93,7 @@ Optionally pass a custom `Parser` with extensions enabled:
 """
 macro docstring_parser(parser = nothing)
     p = parser === nothing ? :(Parser()) : parser
-    quote
+    return quote
         let p = $p
             for (binding, multidoc) in Docs.meta($(__module__))
                 for (sig, docstr) in multidoc.docs

--- a/src/extensions/fenceddivs.jl
+++ b/src/extensions/fenceddivs.jl
@@ -11,20 +11,20 @@ can_contain(::FencedDiv, t) = !(t isa Item)
 finalize(::FencedDiv, ::Parser, ::Node) = nothing
 
 function Node(
-    ::Type{FencedDiv},
-    children...;
-    class::Union{AbstractString,Vector{String}} = String[],
-    id::Union{AbstractString,Nothing} = nothing,
-)
+        ::Type{FencedDiv},
+        children...;
+        class::Union{AbstractString, Vector{String}} = String[],
+        id::Union{AbstractString, Nothing} = nothing,
+    )
     fd = FencedDiv(3)
     node = _build(fd, children)
     classes = class isa AbstractString ? [class] : class
     if !isempty(classes) || id !== nothing
-        node.meta = Dict{String,Any}()
+        node.meta = Dict{String, Any}()
         !isempty(classes) && (node.meta["class"] = classes)
         id !== nothing && (node.meta["id"] = id)
     end
-    node
+    return node
 end
 
 function continue_(::FencedDiv, parser::Parser, container::Node)
@@ -90,7 +90,7 @@ function parse_div_attributes(s::AbstractString)
         # Bare word(s) treated as class names (fenced div specific)
         words = split(s)
         all(w -> occursin(r"^[a-zA-Z_][a-zA-Z0-9_-]*$", w), words) || return nothing
-        return Dict{String,Any}("class" => collect(words))
+        return Dict{String, Any}("class" => collect(words))
     end
 end
 
@@ -122,7 +122,7 @@ block_rule(::FencedDivRule) = Rule(parse_fenced_div, 0.5, ":")
 #
 
 function write_html(::FencedDiv, rend, node, enter)
-    if enter
+    return if enter
         cr(rend)
         tag(rend, "div", attributes(rend, node))
         cr(rend)
@@ -135,7 +135,7 @@ end
 function write_latex(::FencedDiv, w, node, enter)
     classes = getmeta(node, "class", String[])
     env = isempty(classes) ? "fenceddiv" : "fenceddiv@$(first(classes))"
-    if enter
+    return if enter
         cr(w)
         literal(w, "\\begin{$env}\n")
     else
@@ -145,7 +145,7 @@ function write_latex(::FencedDiv, w, node, enter)
 end
 
 function write_typst(::FencedDiv, w, node, enter)
-    if enter
+    return if enter
         cr(w)
         literal(w, "#block[")
         cr(w)
@@ -163,7 +163,7 @@ function write_term(::FencedDiv, rend, node, enter)
     classes = getmeta(node, "class", String[])
     label = isempty(classes) ? "div" : first(classes)
     style = crayon"default bold"
-    if enter
+    return if enter
         header = rpad("┌ $label ", available_columns(rend), "─")
         print_margin(rend)
         print_literal(rend, style, header, inv(style), "\n")
@@ -188,7 +188,7 @@ function write_term(::FencedDiv, rend, node, enter)
 end
 
 function write_markdown(::FencedDiv, w, node, enter)
-    if enter
+    return if enter
         fence = ":"^node.t.fence_length
         print_margin(w)
         literal(w, fence)
@@ -211,7 +211,7 @@ function write_div_attributes(w, meta)
     id = get(meta, "id", nothing)
     other = sort!([(k, v) for (k, v) in meta if k ∉ ("id", "class")], by = first)
     # Simple case: just classes, no id or other attrs
-    if id === nothing && isempty(other) && !isempty(classes)
+    return if id === nothing && isempty(other) && !isempty(classes)
         if length(classes) == 1
             literal(w, first(classes))
         else
@@ -244,7 +244,7 @@ function write_div_attributes(w, meta)
 end
 
 function write_json(::FencedDiv, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else

--- a/src/extensions/footnotes.jl
+++ b/src/extensions/footnotes.jl
@@ -15,8 +15,7 @@ struct FootnoteRule
     cache::Dict{String, Node}
     FootnoteRule() = new(Dict())
 end
-block_rule(fr::FootnoteRule) =
-    Rule(0.5, "[") do parser, container
+block_rule(fr::FootnoteRule) = Rule(0.5, "[") do parser, container
     if !parser.indented
         ln = rest_from_nonspace(parser)
         m = match(r"^\[\^([\w\d]+)\]:[ ]?", ln)
@@ -30,8 +29,7 @@ block_rule(fr::FootnoteRule) =
     end
     return 0
 end
-inline_rule(fr::FootnoteRule) =
-    Rule(0.5, "[") do p, node
+inline_rule(fr::FootnoteRule) = Rule(0.5, "[") do p, node
     m = consume(p, match(r"^\[\^([\w\d]+)]", p))
     m === nothing && return false
     append_child(node, Node(FootnoteLink(m[1], fr)))

--- a/src/extensions/footnotes.jl
+++ b/src/extensions/footnotes.jl
@@ -12,31 +12,31 @@ Here is a footnote reference[^1].
 ```
 """
 struct FootnoteRule
-    cache::Dict{String,Node}
+    cache::Dict{String, Node}
     FootnoteRule() = new(Dict())
 end
 block_rule(fr::FootnoteRule) =
     Rule(0.5, "[") do parser, container
-        if !parser.indented
-            ln = rest_from_nonspace(parser)
-            m = match(r"^\[\^([\w\d]+)\]:[ ]?", ln)
-            if m !== nothing
-                close_unmatched_blocks(parser)
-                fr.cache[m[1]] =
-                    add_child(parser, FootnoteDefinition(m[1]), parser.next_nonspace)
-                advance_offset(parser, length(m.match), false)
-                return 1
-            end
+    if !parser.indented
+        ln = rest_from_nonspace(parser)
+        m = match(r"^\[\^([\w\d]+)\]:[ ]?", ln)
+        if m !== nothing
+            close_unmatched_blocks(parser)
+            fr.cache[m[1]] =
+                add_child(parser, FootnoteDefinition(m[1]), parser.next_nonspace)
+            advance_offset(parser, length(m.match), false)
+            return 1
         end
-        return 0
     end
+    return 0
+end
 inline_rule(fr::FootnoteRule) =
     Rule(0.5, "[") do p, node
-        m = consume(p, match(r"^\[\^([\w\d]+)]", p))
-        m === nothing && return false
-        append_child(node, Node(FootnoteLink(m[1], fr)))
-        return true
-    end
+    m = consume(p, match(r"^\[\^([\w\d]+)]", p))
+    m === nothing && return false
+    append_child(node, Node(FootnoteLink(m[1], fr)))
+    return true
+end
 
 """Footnote definition block. Build with `Node(FootnoteDefinition, "id", children...)`."""
 struct FootnoteDefinition <: AbstractBlock
@@ -45,7 +45,7 @@ end
 
 function Node(::Type{FootnoteDefinition}, id::AbstractString, children...)
     fd = FootnoteDefinition(id)
-    _build(fd, children)
+    return _build(fd, children)
 end
 
 """Footnote reference link. Build with `Node(FootnoteLink, "id")`."""
@@ -82,7 +82,7 @@ end
 # Definitions
 
 function write_html(f::FootnoteDefinition, rend, node, enter)
-    if enter
+    return if enter
         tag(
             rend,
             "div",
@@ -108,7 +108,7 @@ end
 
 function write_term(f::FootnoteDefinition, rend, node, enter)
     style = crayon"red"
-    if enter
+    return if enter
         header = rpad("┌ [^$(f.id)] ", available_columns(rend), "─")
         print_margin(rend)
         print_literal(rend, style, header, inv(style), "\n")
@@ -133,7 +133,7 @@ function write_term(f::FootnoteDefinition, rend, node, enter)
 end
 
 function write_markdown(f::FootnoteDefinition, w, node, ent)
-    if ent
+    return if ent
         push_margin!(w, 1, "[^$(f.id)]: ", " "^4)
     else
         pop_margin!(w)
@@ -151,7 +151,7 @@ function write_html(f::FootnoteLink, rend, node, enter)
         attributes(rend, node, ["href" => "#footnote-$(f.id)", "class" => "footnote"]),
     )
     print(rend.buffer, f.id)
-    tag(rend, "/a")
+    return tag(rend, "/a")
 end
 
 function write_latex(f::FootnoteLink, w, node, enter)
@@ -190,7 +190,7 @@ function write_term(f::FootnoteLink, rend, node, enter)
     push_inline!(rend, style)
     print_literal(rend, "[^", f.id, "]")
     pop_inline!(rend)
-    print_literal(rend, inv(style))
+    return print_literal(rend, inv(style))
 end
 
 write_markdown(f::FootnoteLink, w, node, ent) = literal(w, "[^", f.id, "]")
@@ -211,5 +211,5 @@ function write_json(f::FootnoteLink, ctx, node, enter)
         write_json(child.t, ctx, child, child_enter)
     end
     blocks = pop_container!(ctx)
-    push_element!(ctx, json_el(ctx, "Note", blocks))
+    return push_element!(ctx, json_el(ctx, "Note", blocks))
 end

--- a/src/extensions/frontmatter.jl
+++ b/src/extensions/frontmatter.jl
@@ -80,8 +80,7 @@ struct FrontMatterRule
 end
 
 block_rule(::FrontMatterRule) = Rule(parse_front_matter, 0.5, ";+-")
-block_modifier(f::FrontMatterRule) =
-    Rule(0.5) do parser, node
+block_modifier(f::FrontMatterRule) = Rule(0.5) do parser, node
     if node.t isa FrontMatter
         fence = node.t.fence
         λ = fence == ";;;" ? f.json : fence == "+++" ? f.toml : f.yaml

--- a/src/extensions/frontmatter.jl
+++ b/src/extensions/frontmatter.jl
@@ -1,6 +1,6 @@
 struct FrontMatter <: AbstractBlock
     fence::String
-    data::Dict{String,Any}
+    data::Dict{String, Any}
     FrontMatter(fence) = new(fence, Dict())
 end
 
@@ -74,7 +74,7 @@ struct FrontMatterRule
     yaml::Function
 
     function FrontMatterRule(; fs...)
-        λ = str -> Dict{String,Any}()
+        λ = str -> Dict{String, Any}()
         return new(get(fs, :json, λ), get(fs, :toml, λ), get(fs, :yaml, λ))
     end
 end
@@ -82,17 +82,17 @@ end
 block_rule(::FrontMatterRule) = Rule(parse_front_matter, 0.5, ";+-")
 block_modifier(f::FrontMatterRule) =
     Rule(0.5) do parser, node
-        if node.t isa FrontMatter
-            fence = node.t.fence
-            λ = fence == ";;;" ? f.json : fence == "+++" ? f.toml : f.yaml
-            try
-                merge!(node.t.data, λ(node.literal))
-            catch err
-                node.literal = string(err)
-            end
+    if node.t isa FrontMatter
+        fence = node.t.fence
+        λ = fence == ";;;" ? f.json : fence == "+++" ? f.toml : f.yaml
+        try
+            merge!(node.t.data, λ(node.literal))
+        catch err
+            node.literal = string(err)
         end
-        return nothing
     end
+    return nothing
+end
 
 # Frontmatter isn't displayed in the resulting output.
 
@@ -106,7 +106,7 @@ function write_markdown(f::FrontMatter, w, node, ent)
     # If frontmatter is not well-formed then it won't be round-trippable.
     literal(w, node.literal)
     literal(w, f.fence, "\n")
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
 # Frontmatter is handled at the top-level in JSON writer (populates meta).

--- a/src/extensions/github_alerts.jl
+++ b/src/extensions/github_alerts.jl
@@ -12,14 +12,14 @@ struct GitHubAlert <: AbstractBlock
 end
 
 function Node(
-    ::Type{GitHubAlert},
-    category::AbstractString,
-    children...;
-    title::Union{AbstractString,Nothing} = nothing,
-)
+        ::Type{GitHubAlert},
+        category::AbstractString,
+        children...;
+        title::Union{AbstractString, Nothing} = nothing,
+    )
     cat = lowercase(category)
     t = title === nothing ? get(GITHUB_ALERT_TYPES, cat, titlecase(cat)) : title
-    _build(GitHubAlert(cat, t), children)
+    return _build(GitHubAlert(cat, t), children)
 end
 
 is_container(::GitHubAlert) = true
@@ -55,33 +55,33 @@ struct GitHubAlertRule end
 
 block_modifier(::GitHubAlertRule) =
     Rule(50) do parser, block
-        if block.t isa BlockQuote
-            child = block.first_child
-            if !isnull(child) && child.t isa Paragraph
-                m = match(
-                    r"^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\n?"i,
-                    child.literal,
-                )
-                if m !== nothing
-                    category = lowercase(m[1])
-                    title = GITHUB_ALERT_TYPES[category]
-                    block.t = GitHubAlert(category, title)
-                    child.literal = child.literal[length(m.match)+1:end]
-                    if isempty(strip(child.literal))
-                        unlink(child)
-                    end
+    if block.t isa BlockQuote
+        child = block.first_child
+        if !isnull(child) && child.t isa Paragraph
+            m = match(
+                r"^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\n?"i,
+                child.literal,
+            )
+            if m !== nothing
+                category = lowercase(m[1])
+                title = GITHUB_ALERT_TYPES[category]
+                block.t = GitHubAlert(category, title)
+                child.literal = child.literal[(length(m.match) + 1):end]
+                if isempty(strip(child.literal))
+                    unlink(child)
                 end
             end
         end
-        return nothing
     end
+    return nothing
+end
 
 #
 # Writers
 #
 
 function write_html(a::GitHubAlert, rend, node, enter)
-    if enter
+    return if enter
         cr(rend)
         tag(rend, "div", attributes(rend, node, ["class" => "github-alert $(a.category)"]))
         tag(rend, "p", ["class" => "github-alert-title"])
@@ -95,7 +95,7 @@ function write_html(a::GitHubAlert, rend, node, enter)
 end
 
 function write_latex(a::GitHubAlert, w, node, enter)
-    if enter
+    return if enter
         cr(w)
         literal(w, "\\begin{githubalert@$(a.category)}{$(a.title)}\n")
     else
@@ -105,7 +105,7 @@ function write_latex(a::GitHubAlert, w, node, enter)
 end
 
 function write_typst(a::GitHubAlert, w, node, enter)
-    if enter
+    return if enter
         styles = Dict(
             "note" => "#0969da",
             "tip" => "#1a7f37",
@@ -138,7 +138,7 @@ function write_term(a::GitHubAlert, rend, node, enter)
         "caution" => crayon"red bold",
     )
     style = get(styles, a.category, crayon"default bold")
-    if enter
+    return if enter
         header = rpad("┌ $(a.title) ", available_columns(rend), "─")
         print_margin(rend)
         print_literal(rend, style, header, inv(style), "\n")
@@ -163,7 +163,7 @@ function write_term(a::GitHubAlert, rend, node, enter)
 end
 
 function write_markdown(a::GitHubAlert, w, node, ent)
-    if ent
+    return if ent
         push_margin!(w, "> ")
         print_margin(w)
         literal(w, "[!", uppercase(a.category), "]\n")
@@ -174,7 +174,7 @@ function write_markdown(a::GitHubAlert, w, node, ent)
 end
 
 function write_json(a::GitHubAlert, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else

--- a/src/extensions/github_alerts.jl
+++ b/src/extensions/github_alerts.jl
@@ -53,8 +53,7 @@ styled alert boxes. Supported types: NOTE, TIP, IMPORTANT, WARNING, CAUTION.
 """
 struct GitHubAlertRule end
 
-block_modifier(::GitHubAlertRule) =
-    Rule(50) do parser, block
+block_modifier(::GitHubAlertRule) = Rule(50) do parser, block
     if block.t isa BlockQuote
         child = block.first_child
         if !isnull(child) && child.t isa Paragraph

--- a/src/extensions/grid_tables.jl
+++ b/src/extensions/grid_tables.jl
@@ -116,13 +116,13 @@ function _build_grid_table(parser::Parser, lines::AbstractVector)
     separators = String[string(strip(lines[1]))]
     current_section = String[]
 
-    for i = 2:length(lines)
+    for i in 2:length(lines)
         line = lines[i]
         stripped = strip(line)
         if _is_full_border(line) && (
-            all(p -> p <= lastindex(line) && line[p] == '+', col_positions) ||
-            occursin('=', stripped)
-        )
+                all(p -> p <= lastindex(line) && line[p] == '+', col_positions) ||
+                    occursin('=', stripped)
+            )
             push!(sections, current_section)
             push!(separators, string(stripped))
             current_section = String[]
@@ -137,7 +137,7 @@ function _build_grid_table(parser::Parser, lines::AbstractVector)
     has_footer =
         length(separators) > 2 &&
         occursin('=', separators[end]) &&
-        occursin('=', separators[end-1])
+        occursin('=', separators[end - 1])
     if has_header && has_footer && length(sections) == 1
         has_footer = false
     end
@@ -165,7 +165,7 @@ function _build_grid_table(parser::Parser, lines::AbstractVector)
     if body_start <= body_end
         body = Node(TableBody())
         append_child(table, body)
-        for i = body_start:body_end
+        for i in body_start:body_end
             _parse_row_group!(
                 parser,
                 body,
@@ -201,9 +201,9 @@ function _parse_grid_spec(border::AbstractString, col_positions::Vector{Int})
     widths = Vector{Float64}(undef, ncols)
     total = 0.0
 
-    for i = 1:ncols
+    for i in 1:ncols
         start = col_positions[i] + 1
-        stop = col_positions[i+1] - 1
+        stop = col_positions[i + 1] - 1
         spec[i] = :left
         widths[i] = Float64(max(stop - start + 1, 1))
         total += widths[i]
@@ -215,12 +215,12 @@ end
 # Check if a content line is a partial border (contains + grid markers not at all positions).
 function _is_partial_border(line, col_positions)
     _is_full_border(line) && return false
-    for pos in col_positions[2:end-1]
+    for pos in col_positions[2:(end - 1)]
         if pos <= lastindex(line) &&
-           isvalid(line, pos) &&
-           line[pos] == '+' &&
-           pos < lastindex(line) &&
-           line[pos+1] in ('-', '=')
+                isvalid(line, pos) &&
+                line[pos] == '+' &&
+                pos < lastindex(line) &&
+                line[pos + 1] in ('-', '=')
             return true
         end
     end
@@ -263,40 +263,40 @@ end
 
 # Emit a rowspan group: multiple sub-rows with colspan/rowspan detection.
 function _emit_rowspan_group!(
-    parser,
-    parent,
-    sub_groups,
-    partial_borders,
-    border_above,
-    col_positions,
-    spec,
-    is_header,
-)
+        parser,
+        parent,
+        sub_groups,
+        partial_borders,
+        border_above,
+        col_positions,
+        spec,
+        is_header,
+    )
     ncols = length(col_positions) - 1
     n_sub = length(sub_groups)
 
-    sub_row_cells = Vector{Vector{NamedTuple{(:col, :colspan),Tuple{Int,Int}}}}()
+    sub_row_cells = Vector{Vector{NamedTuple{(:col, :colspan), Tuple{Int, Int}}}}()
 
     above_plus = _partial_border_positions(border_above, col_positions)
     push!(sub_row_cells, _detect_colspan_from_plus(col_positions, above_plus))
 
-    for k = 2:n_sub
-        border_plus = _partial_border_positions(partial_borders[k-1], col_positions)
+    for k in 2:n_sub
+        border_plus = _partial_border_positions(partial_borders[k - 1], col_positions)
         push!(sub_row_cells, _detect_colspan_from_plus(col_positions, border_plus))
     end
 
     # Build an occupation grid and cell registry for rowspan merging.
     cell_registry =
-        NamedTuple{(:col, :colspan, :rowspan, :sub_rows),Tuple{Int,Int,Int,Vector{Int}}}[]
-    occupied = [zeros(Int, ncols) for _ = 1:n_sub]
+        NamedTuple{(:col, :colspan, :rowspan, :sub_rows), Tuple{Int, Int, Int, Vector{Int}}}[]
+    occupied = [zeros(Int, ncols) for _ in 1:n_sub]
 
-    for sr = 1:n_sub
+    for sr in 1:n_sub
         for cell_def in sub_row_cells[sr]
             col, cspan = cell_def.col, cell_def.colspan
             occupied[sr][col] != 0 && continue
             rspan = 1
-            for next_sr = sr+1:n_sub
-                pb = partial_borders[next_sr-1]
+            for next_sr in (sr + 1):n_sub
+                pb = partial_borders[next_sr - 1]
                 left_pos = col_positions[col]
                 if left_pos <= lastindex(pb) && pb[left_pos] == '+'
                     break
@@ -310,11 +310,11 @@ function _emit_rowspan_group!(
                     col = col,
                     colspan = cspan,
                     rowspan = rspan,
-                    sub_rows = collect(sr:sr+rspan-1),
+                    sub_rows = collect(sr:(sr + rspan - 1)),
                 ),
             )
-            for osr = sr:sr+rspan-1
-                for c = col:col+cspan-1
+            for osr in sr:(sr + rspan - 1)
+                for c in col:(col + cspan - 1)
                     occupied[osr][c] = cell_id
                 end
             end
@@ -349,7 +349,7 @@ function _emit_rowspan_group!(
         cell_nodes[cell_id] = cell_node
     end
 
-    for sr = 1:n_sub
+    for sr in 1:n_sub
         row = Node(TableRow())
         append_child(group, row)
         for (cell_id, cell_def) in enumerate(cell_registry)
@@ -357,22 +357,23 @@ function _emit_rowspan_group!(
             append_child(row, cell_nodes[cell_id])
         end
     end
+    return
 end
 
 function _parse_row_group!(
-    parser,
-    parent,
-    content_lines,
-    border_above,
-    col_positions,
-    spec,
-    is_header,
-)
+        parser,
+        parent,
+        content_lines,
+        border_above,
+        col_positions,
+        spec,
+        is_header,
+    )
     isempty(content_lines) && return
 
     sub_groups, partial_borders = _split_by_partial_borders(content_lines, col_positions)
 
-    if length(sub_groups) == 1
+    return if length(sub_groups) == 1
         above_plus = _partial_border_positions(border_above, col_positions)
         _emit_row!(
             parser,
@@ -406,7 +407,7 @@ function _build_vcol_map(s::AbstractString)
     map = Int[]
     for i in eachindex(s)
         w = max(textwidth(s[i]), 1)
-        for _ = 1:w
+        for _ in 1:w
             push!(map, i)
         end
     end
@@ -417,7 +418,7 @@ end
 # Extract cell content lines from raw grid lines for the given column span.
 function _extract_cell_lines(lines, col_positions, col, cspan, vcol_maps)
     start_vcol = col_positions[col] + 1
-    stop_vcol = col_positions[col+cspan] - 1
+    stop_vcol = col_positions[col + cspan] - 1
     cell_lines = String[]
     for (line, vmap) in zip(lines, vcol_maps)
         if vmap === nothing
@@ -435,7 +436,7 @@ function _extract_cell_lines(lines, col_positions, col, cspan, vcol_maps)
                 push!(cell_lines, "")
             else
                 eb =
-                    stop_vcol + 1 <= length(vmap) ? vmap[stop_vcol+1] - 1 : ncodeunits(line)
+                    stop_vcol + 1 <= length(vmap) ? vmap[stop_vcol + 1] - 1 : ncodeunits(line)
                 push!(cell_lines, String(SubString(line, sb, min(eb, ncodeunits(line)))))
             end
         end
@@ -446,12 +447,12 @@ end
 # Detect colspan from a set of + positions in a border line.
 function _detect_colspan_from_plus(col_positions, plus_set::Set{Int})
     ncols = length(col_positions) - 1
-    cells = NamedTuple{(:col, :colspan),Tuple{Int,Int}}[]
+    cells = NamedTuple{(:col, :colspan), Tuple{Int, Int}}[]
     col = 1
     while col <= ncols
         span = 1
         while col + span <= ncols
-            pos = col_positions[col+span]
+            pos = col_positions[col + span]
             pos in plus_set && break
             span += 1
         end
@@ -463,14 +464,14 @@ end
 
 # Emit a single row with colspan detection (no partial borders / no rowspan).
 function _emit_row!(
-    parser,
-    parent,
-    content_lines,
-    col_positions,
-    above_plus,
-    spec,
-    is_header,
-)
+        parser,
+        parent,
+        content_lines,
+        col_positions,
+        above_plus,
+        spec,
+        is_header,
+    )
     isempty(content_lines) && return
 
     cells = _detect_colspan_from_plus(col_positions, above_plus)
@@ -490,6 +491,7 @@ function _emit_row!(
         _parse_cell_content!(parser, cell_node, cell_content)
         append_child(row, cell_node)
     end
+    return
 end
 
 function _parse_cell_content!(parser, cell_node, cell_content)
@@ -506,6 +508,7 @@ function _parse_cell_content!(parser, cell_node, cell_content)
         append_child(cell_node, child)
         child = nxt
     end
+    return
 end
 
 function _strip_cell_padding(lines::Vector{String})
@@ -569,22 +572,22 @@ end
 # `bounds_above`/`bounds_below` are sets of column indices where cell boundaries exist
 # in the row above/below. Junction char is chosen based on which sides have boundaries.
 function _write_term_border(
-    rend,
-    col_widths,
-    bounds_above,
-    bounds_below,
-    ncols,
-    left,
-    fill,
-    junc_cross,
-    junc_down,
-    junc_up,
-    right,
-)
+        rend,
+        col_widths,
+        bounds_above,
+        bounds_below,
+        ncols,
+        left,
+        fill,
+        junc_cross,
+        junc_down,
+        junc_up,
+        right,
+    )
     print_margin(rend)
     buf = rend.format.buffer
     print(buf, left, fill)
-    for i = 1:ncols
+    for i in 1:ncols
         print(buf, fill^col_widths[i])
         if i < ncols
             above = (i + 1) in bounds_above
@@ -600,7 +603,7 @@ function _write_term_border(
             end
         end
     end
-    println(buf, fill, right)
+    return println(buf, fill, right)
 end
 
 # Write a partial border between visual sub-rows.
@@ -609,18 +612,18 @@ end
 # Junction characters depend on whether boundaries exist above and/or below:
 #   above+below: ┼   below only: ┬   above only: ┴
 function _write_term_partial_border(
-    rend,
-    col_widths,
-    spanning_cols,
-    cells_above,
-    cells_below,
-    ncols,
-)
+        rend,
+        col_widths,
+        spanning_cols,
+        cells_above,
+        cells_below,
+        ncols,
+    )
     bounds_above = _cell_boundaries(cells_above, ncols)
     bounds_below = _cell_boundaries(cells_below, ncols)
     print_margin(rend)
     buf = rend.format.buffer
-    for i = 1:ncols
+    for i in 1:ncols
         span = spanning_cols[i]
         fill_char = span ? ' ' : '─'
         above = i in bounds_above
@@ -629,7 +632,7 @@ function _write_term_partial_border(
         if i == 1
             print(buf, span ? "┃" : "┠", fill_char)
         else
-            prev_span = spanning_cols[i-1]
+            prev_span = spanning_cols[i - 1]
             if prev_span && span
                 print(buf, "   ")
             elseif prev_span && !span
@@ -663,6 +666,7 @@ function _write_term_partial_border(
             end
         end
     end
+    return
 end
 
 # Pre-render all term cells, computing column widths from content.
@@ -678,7 +682,7 @@ function _prerender_term_cells(rend, table_node, gt::GridTable)
         fill(max(1, fld(budget, ncols)), ncols)
     end
 
-    rendered = Dict{Node,Vector{String}}()
+    rendered = Dict{Node, Vector{String}}()
     col_widths = fill(1, ncols)
 
     for (n, ent) in table_node
@@ -688,7 +692,7 @@ function _prerender_term_cells(rend, table_node, gt::GridTable)
                 target_widths[tc.column]
             elseif tc.colspan > 1 && tc.column + tc.colspan - 1 <= ncols
                 tw =
-                    sum(target_widths[tc.column:tc.column+tc.colspan-1]) +
+                    sum(target_widths[tc.column:(tc.column + tc.colspan - 1)]) +
                     3 * (tc.colspan - 1)
                 tw > 0 ? tw : -1
             else
@@ -749,7 +753,7 @@ function _write_grid_table_term(rend, table_node, gt::GridTable)
                 )
             end
 
-            for line_idx = 1:max_lines
+            for line_idx in 1:max_lines
                 print_margin(rend)
                 for (ci, cell) in enumerate(active_cells)
                     col = cell.t.column
@@ -790,7 +794,7 @@ function _write_grid_table_term(rend, table_node, gt::GridTable)
         # Full border after group.
         last_subrow_cells = _get_active_cells_for_subrow(subrows, length(subrows), ncols)
         if grp_idx < length(group_data)
-            next_subrows = group_data[grp_idx+1][1]
+            next_subrows = group_data[grp_idx + 1][1]
             next_first_cells = next_subrows[1]
             bounds_above = _cell_boundaries(last_subrow_cells, ncols)
             bounds_below = _cell_boundaries(next_first_cells, ncols)
@@ -840,6 +844,7 @@ function _write_grid_table_term(rend, table_node, gt::GridTable)
             )
         end
     end
+    return
 end
 
 # Markdown: render entire grid table, suppressing child traversal.
@@ -874,18 +879,19 @@ function _redistribute_spanning_widths!(col_widths, table_node, rendered, width_
             if max_w > combined
                 excess = max_w - combined
                 per_col = cld(excess, tc.colspan)
-                for c = tc.column:tc.column+tc.colspan-1
+                for c in tc.column:(tc.column + tc.colspan - 1)
                     col_widths[c] += per_col
                 end
             end
         end
     end
+    return
 end
 
 # Distribute rendered lines across sub-rows for rowspan cells.
 function _distribute_rowspan_lines(subrows, rendered)
     all_cells = _flatten_subrows(subrows)
-    cell_subrow_lines = Dict{Node,Vector{Vector{String}}}()
+    cell_subrow_lines = Dict{Node, Vector{Vector{String}}}()
     for cell in all_cells
         tc = cell.t
         lines = get(rendered, cell, String[""])
@@ -893,7 +899,7 @@ function _distribute_rowspan_lines(subrows, rendered)
             n_visual = tc.rowspan
             lines_per = cld(length(lines), n_visual)
             dist = Vector{Vector{String}}()
-            for sr = 1:n_visual
+            for sr in 1:n_visual
                 start_l = (sr - 1) * lines_per + 1
                 end_l = min(sr * lines_per, length(lines))
                 if start_l <= length(lines)
@@ -929,13 +935,13 @@ function _compute_partial_border_info(active_cells, subrows, sr_idx, ncols)
         tc = cell.t
         cell_start = _cell_start_subrow(cell, subrows)
         if cell_start + tc.rowspan - 1 > sr_idx
-            col_range = tc.column:tc.column+tc.colspan-1
+            col_range = tc.column:(tc.column + tc.colspan - 1)
             next_occupied[col_range] .= true
         end
     end
     next_sr_cells = Node[]
-    for cell in subrows[sr_idx+1]
-        col_range = cell.t.column:cell.t.column+cell.t.colspan-1
+    for cell in subrows[sr_idx + 1]
+        col_range = cell.t.column:(cell.t.column + cell.t.colspan - 1)
         if !any(next_occupied[col_range])
             push!(next_sr_cells, cell)
         end
@@ -948,7 +954,7 @@ end
 # plus separator space absorbed (3 chars per internal separator: " | ").
 function _spanning_width(col_widths, col, colspan)
     w = 0
-    for i = col:col+colspan-1
+    for i in col:(col + colspan - 1)
         w += col_widths[i]
     end
     w += 3 * (colspan - 1)
@@ -959,13 +965,13 @@ end
 # Guarantees sum(result) == budget exactly.
 function _allocate_column_widths(proportions::Vector{Float64}, budget::Int, ncols::Int)
     widths = Vector{Int}(undef, ncols)
-    for i = 1:ncols
+    for i in 1:ncols
         widths[i] = max(1, floor(Int, proportions[i] * budget))
     end
     remainder = budget - sum(widths)
-    fracs = [proportions[i] * budget - floor(proportions[i] * budget) for i = 1:ncols]
+    fracs = [proportions[i] * budget - floor(proportions[i] * budget) for i in 1:ncols]
     order = sortperm(fracs; rev = true)
-    for i = 1:min(remainder, ncols)
+    for i in 1:min(remainder, ncols)
         widths[order[i]] += 1
     end
     return widths
@@ -997,7 +1003,7 @@ end
 function _collect_row_groups(table_node)
     groups = NamedTuple{
         (:subrows, :is_header, :after_header, :before_footer, :is_footer),
-        Tuple{Vector{Vector{Node}},Bool,Bool,Bool,Bool},
+        Tuple{Vector{Vector{Node}}, Bool, Bool, Bool, Bool},
     }[]
     child = table_node.first_child
     while !isnull(child)
@@ -1074,7 +1080,7 @@ function _write_grid_table_markdown(w, table_node, gt::GridTable)
     ncols = length(spec)
 
     # Pre-render all cells and collect per-fine-column width requirements.
-    rendered = Dict{Node,Vector{String}}()
+    rendered = Dict{Node, Vector{String}}()
     col_widths = fill(3, ncols)
 
     for (n, ent) in table_node
@@ -1121,7 +1127,7 @@ function _write_grid_table_markdown(w, table_node, gt::GridTable)
                 )
             end
 
-            for line_idx = 1:max_lines
+            for line_idx in 1:max_lines
                 print_margin(w)
                 for cell in active_cells
                     col = cell.t.column
@@ -1155,7 +1161,7 @@ function _write_grid_table_markdown(w, table_node, gt::GridTable)
         # Full border after group.
         last_subrow_cells = _get_active_cells_for_subrow(subrows, length(subrows), ncols)
         if grp_idx < length(group_data)
-            next_subrows = group_data[grp_idx+1][1]
+            next_subrows = group_data[grp_idx + 1][1]
             next_first_cells = next_subrows[1]
             _write_grid_border_between_rows(
                 w,
@@ -1170,6 +1176,7 @@ function _write_grid_table_markdown(w, table_node, gt::GridTable)
             _write_grid_border_for_cells(w, col_widths, spec, sep, last_subrow_cells, ncols)
         end
     end
+    return
 end
 
 # Find which sub-row a cell starts in.
@@ -1186,12 +1193,12 @@ end
 function _get_active_cells_for_subrow(subrows, sr_idx, ncols)
     active = Node[]
     occupied = falses(ncols)
-    for prev_sr = 1:sr_idx
+    for prev_sr in 1:sr_idx
         for cell in subrows[prev_sr]
             tc = cell.t
             cell_spans_here = (prev_sr == sr_idx) || (prev_sr + tc.rowspan - 1 >= sr_idx)
             if cell_spans_here
-                col_range = tc.column:tc.column+tc.colspan-1
+                col_range = tc.column:(tc.column + tc.colspan - 1)
                 if !any(occupied[col_range])
                     push!(active, cell)
                     occupied[col_range] .= true
@@ -1209,7 +1216,7 @@ function _write_grid_border_for_cells(w, col_widths, spec, sep::Char, cells, nco
 
     print_margin(w)
     s = string(sep)
-    for i = 1:ncols
+    for i in 1:ncols
         if i in bounds
             literal(w, "+")
         else
@@ -1218,24 +1225,24 @@ function _write_grid_border_for_cells(w, col_widths, spec, sep::Char, cells, nco
         literal(w, s^(col_widths[i] + 2))
     end
     literal(w, "+")
-    cr(w)
+    return cr(w)
 end
 
 # Write a border between two rows, merging cell boundaries from both.
 function _write_grid_border_between_rows(
-    w,
-    col_widths,
-    spec,
-    sep::Char,
-    cells_above,
-    cells_below,
-    ncols,
-)
+        w,
+        col_widths,
+        spec,
+        sep::Char,
+        cells_above,
+        cells_below,
+        ncols,
+    )
     bounds = _cell_boundaries(cells_below, ncols)
 
     print_margin(w)
     s = string(sep)
-    for i = 1:ncols
+    for i in 1:ncols
         if i in bounds
             literal(w, "+")
         else
@@ -1244,24 +1251,24 @@ function _write_grid_border_between_rows(
         literal(w, s^(col_widths[i] + 2))
     end
     literal(w, "+")
-    cr(w)
+    return cr(w)
 end
 
 # Write a partial border between sub-rows within the same row group.
 # Rowspan cells from above that span past this border get | and spaces instead of + and ---.
 function _write_grid_partial_border(
-    w,
-    col_widths,
-    sep::Char,
-    spanning_cols::BitVector,
-    cells_below,
-    ncols,
-)
+        w,
+        col_widths,
+        sep::Char,
+        spanning_cols::BitVector,
+        cells_below,
+        ncols,
+    )
     bounds_below = _cell_boundaries(cells_below, ncols)
 
     print_margin(w)
     s = string(sep)
-    for i = 1:ncols
+    for i in 1:ncols
         if spanning_cols[i]
             literal(w, "|")
             literal(w, " "^(col_widths[i] + 2))
@@ -1275,5 +1282,5 @@ function _write_grid_partial_border(
         end
     end
     literal(w, "+")
-    cr(w)
+    return cr(w)
 end

--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -27,26 +27,26 @@ const reInterpHere = r"^\$"
 
 inline_rule(ji::JuliaInterpolationRule) =
     Rule(1, "\$") do p, node
-        dollar = match(reInterpHere, p)
-        if dollar === nothing || length(dollar.match) > 1
+    dollar = match(reInterpHere, p)
+    if dollar === nothing || length(dollar.match) > 1
+        return false
+    else
+        consume(p, dollar)
+        after_opener, count = position(p), length(dollar.match)
+        ex, after_expr = Meta.parse(rest(p), 1; greedy = false, raise = false)
+        after_expr += after_opener
+        if Meta.isexpr(ex, [:error, :incomplete])
+            # Bails out on Julia parse errors, do we rather want to propagate them?
             return false
         else
-            consume(p, dollar)
-            after_opener, count = position(p), length(dollar.match)
-            ex, after_expr = Meta.parse(rest(p), 1; greedy = false, raise = false)
-            after_expr += after_opener
-            if Meta.isexpr(ex, [:error, :incomplete])
-                # Bails out on Julia parse errors, do we rather want to propagate them?
-                return false
-            else
-                seek(p, after_expr - 1) # Offset Meta.parse end position.
-                ref = JuliaExpression(length(ji.captured) + 1, ex)
-                push!(ji.captured, ref)
-                append_child(node, Node(ref))
-                return true
-            end
+            seek(p, after_expr - 1) # Offset Meta.parse end position.
+            ref = JuliaExpression(length(ji.captured) + 1, ex)
+            push!(ji.captured, ref)
+            append_child(node, Node(ref))
+            return true
         end
     end
+end
 
 export @cm_str
 
@@ -123,11 +123,13 @@ macro cm_str(str, name = "jmd")
     # values.
     expr = Expr(:block, :(values = []))
     for v in ji.captured
-        push!(expr.args, :(
-            let x = $(esc(v.ex))
-                push!(values, x)
-            end
-        ))
+        push!(
+            expr.args, :(
+                let x = $(esc(v.ex))
+                    push!(values, x)
+                end
+            )
+        )
     end
     push!(expr.args, :(_interp!($ast, $(ji.captured), values)))
     return expr
@@ -186,24 +188,24 @@ end
 function write_html(jv::JuliaExpression, rend, node, enter)
     tag(rend, "span", attributes(rend, node, ["class" => "julia-expr"]))
     print(rend.buffer, sprint(print, '$', "($(jv.ex))"))
-    tag(rend, "/span")
+    return tag(rend, "/span")
 end
 
 function write_latex(jv::JuliaExpression, rend, node, enter)
     print(rend.buffer, "\\texttt{", '\\', '$', '(')
     latex_escape(rend, string(jv.ex))
-    print(rend.buffer, ")}")
+    return print(rend.buffer, ")}")
 end
 
 function write_typst(jv::JuliaExpression, rend, node, enter)
-    print(rend.buffer, string(jv.ex))
+    return print(rend.buffer, string(jv.ex))
 end
 
 function write_term(jv::JuliaExpression, rend, node, enter)
     style = crayon"yellow"
     push_inline!(rend, style)
     print_literal(rend, style, sprint(print, '$', "($(jv.ex))"), inv(style))
-    pop_inline!(rend)
+    return pop_inline!(rend)
 end
 
 # JuliaValue
@@ -211,18 +213,19 @@ end
 function write_html(jv::JuliaValue, rend, node, enter)
     tag(rend, "span", attributes(rend, node, ["class" => "julia-value"]))
     print(rend.buffer, sprint(_showas, MIME("text/html"), jv.ref; context = rend.buffer))
-    tag(rend, "/span")
+    return tag(rend, "/span")
 end
 
 function write_latex(jv::JuliaValue, rend, node, enter)
-    print(rend.buffer, sprint(_showas, MIME("text/latex"), jv.ref))
+    return print(rend.buffer, sprint(_showas, MIME("text/latex"), jv.ref))
 end
 
-function _showas(io::IO, m::MIME, collection::Union{Tuple,AbstractArray,Base.Generator})
+function _showas(io::IO, m::MIME, collection::Union{Tuple, AbstractArray, Base.Generator})
     for each in collection
         _showas(io, m, each)
         print(io, " ")
     end
+    return
 end
 _showas(io::IO, m::MIME, obj) = showable(m, obj) ? show(io, m, obj) : print(io, obj)
 
@@ -230,22 +233,22 @@ function write_term(jv::JuliaValue, rend, node, enter)
     style = crayon"yellow"
     push_inline!(rend, style)
     print_literal(rend, style, sprint(print, jv.ref), inv(style))
-    pop_inline!(rend)
+    return pop_inline!(rend)
 end
 
 function write_typst(jv::JuliaValue, rend, node, enter)
-    literal(rend, sprint(print, jv.ref))
+    return literal(rend, sprint(print, jv.ref))
 end
 
 # Markdown output should be roundtrip-able, so printout the interpolated
 # expression rather than it's value.
-write_markdown(jv::Union{JuliaExpression,JuliaValue}, rend, node, ent) =
+write_markdown(jv::Union{JuliaExpression, JuliaValue}, rend, node, ent) =
     print(rend.buffer, '$', "($(jv.ex))")
 
 # Render evaluated values as text.
 function write_json(jv::JuliaValue, ctx, node, enter)
     enter || return
-    append!(current(ctx), text_to_inlines(string(jv.ref)))
+    return append!(current(ctx), text_to_inlines(string(jv.ref)))
 end
 
 write_json(::JuliaExpression, ctx, node, enter) = nothing

--- a/src/extensions/interpolation.jl
+++ b/src/extensions/interpolation.jl
@@ -25,8 +25,7 @@ end
 
 const reInterpHere = r"^\$"
 
-inline_rule(ji::JuliaInterpolationRule) =
-    Rule(1, "\$") do p, node
+inline_rule(ji::JuliaInterpolationRule) = Rule(1, "\$") do p, node
     dollar = match(reInterpHere, p)
     if dollar === nothing || length(dollar.match) > 1
         return false

--- a/src/extensions/mark.jl
+++ b/src/extensions/mark.jl
@@ -38,16 +38,16 @@ write_html(::Mark, r, n, ent) = tag(r, ent ? "mark" : "/mark", ent ? attributes(
 
 function write_latex(::Mark, w, n, ent)
     # Requires \usepackage{soul}
-    print(w.buffer, ent ? "\\hl{" : "}")
+    return print(w.buffer, ent ? "\\hl{" : "}")
 end
 
 function write_typst(::Mark, w, n, ent)
-    print(w.buffer, ent ? "#highlight[" : "]")
+    return print(w.buffer, ent ? "#highlight[" : "]")
 end
 
 function write_term(::Mark, w, n, ent)
     style = crayon"negative"
-    if ent
+    return if ent
         print_literal(w, style)
         push_inline!(w, style)
     else
@@ -57,11 +57,11 @@ function write_term(::Mark, w, n, ent)
 end
 
 function write_markdown(::Mark, w, n, ent)
-    literal(w, "==")
+    return literal(w, "==")
 end
 
 function write_json(::Mark, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else

--- a/src/extensions/math.jl
+++ b/src/extensions/math.jl
@@ -79,8 +79,7 @@ Display:
 ````
 """
 struct MathRule end
-block_modifier(::MathRule) =
-    Rule(1.5) do parser, node
+block_modifier(::MathRule) = Rule(1.5) do parser, node
     if node.t isa CodeBlock && node.t.info == "math"
         node.t = DisplayMath()
         node.literal = strip(node.literal, '\n')

--- a/src/extensions/math.jl
+++ b/src/extensions/math.jl
@@ -12,7 +12,7 @@ end
 function Node(::Type{Math}, s::AbstractString)
     node = Node(Math())
     node.literal = s
-    node
+    return node
 end
 
 function parse_inline_math_backticks(p::InlineParser, node::Node)
@@ -53,12 +53,12 @@ end
 function Node(::Type{DisplayMath}, s::AbstractString)
     node = Node(DisplayMath())
     node.literal = s
-    node
+    return node
 end
 
 function handle_fenced_math_block(node::Node, info, source)
     node.t = DisplayMath()
-    node.literal = strip(source, '\n')
+    return node.literal = strip(source, '\n')
 end
 
 """
@@ -81,12 +81,12 @@ Display:
 struct MathRule end
 block_modifier(::MathRule) =
     Rule(1.5) do parser, node
-        if node.t isa CodeBlock && node.t.info == "math"
-            node.t = DisplayMath()
-            node.literal = strip(node.literal, '\n')
-        end
-        return nothing
+    if node.t isa CodeBlock && node.t.info == "math"
+        node.t = DisplayMath()
+        node.literal = strip(node.literal, '\n')
     end
+    return nothing
+end
 inline_rule(::MathRule) = Rule(parse_inline_math_backticks, 0, "`")
 
 #
@@ -167,16 +167,16 @@ function write_html(m::Math, rend, node, enter)
     delims = m.display ? ("\\[", "\\]") : ("\\(", "\\)")
     tag(rend, "span", attributes(rend, node, ["class" => cls]))
     print(rend.buffer, delims[1], node.literal, delims[2])
-    tag(rend, "/span")
+    return tag(rend, "/span")
 end
 
 function write_latex(m::Math, rend, node, enter)
     delims = m.display ? ("\\[", "\\]") : ("\\(", "\\)")
-    print(rend.buffer, delims[1], node.literal, delims[2])
+    return print(rend.buffer, delims[1], node.literal, delims[2])
 end
 
 function write_typst(m::Math, rend, node, enter)
-    if m.display
+    return if m.display
         print(rend.buffer, "\$ ", strip(node.literal), " \$")
     else
         print(rend.buffer, "\$", strip(node.literal), "\$")
@@ -187,11 +187,11 @@ function write_term(::Math, rend, node, enter)
     style = crayon"magenta"
     push_inline!(rend, style)
     print_literal(rend, style, node.literal, inv(style))
-    pop_inline!(rend)
+    return pop_inline!(rend)
 end
 
 function write_markdown(m::Math, w, node, ent)
-    if m.dollar
+    return if m.dollar
         delim = m.display ? "\$\$" : "\$"
         content = node.literal
         if !m.display && isempty(content)
@@ -211,19 +211,19 @@ end
 function write_html(::DisplayMath, rend, node, enter)
     tag(rend, "div", attributes(rend, node, ["class" => "display-math tex"]))
     print(rend.buffer, "\\[", node.literal, "\\]")
-    tag(rend, "/div")
+    return tag(rend, "/div")
 end
 
 function write_latex(::DisplayMath, rend, node, enter)
     println(rend.buffer, "\\begin{equation*}")
     println(rend.buffer, node.literal)
-    println(rend.buffer, "\\end{equation*}")
+    return println(rend.buffer, "\\end{equation*}")
 end
 
 function write_typst(::DisplayMath, rend, node, enter)
     print(rend.buffer, "\$ ")
     print(rend.buffer, strip(node.literal))
-    println(rend.buffer, " \$")
+    return println(rend.buffer, " \$")
 end
 
 function write_term(::DisplayMath, rend, node, enter)
@@ -234,14 +234,14 @@ function write_term(::DisplayMath, rend, node, enter)
         print_literal(rend, "  ", pipe, "│", inv(pipe), " ")
         print_literal(rend, style, line, inv(style), "\n")
     end
-    if !isnull(node.nxt)
+    return if !isnull(node.nxt)
         print_margin(rend)
         print_literal(rend, "\n")
     end
 end
 
 function write_markdown(m::DisplayMath, w, node, ent)
-    if m.dollar
+    return if m.dollar
         print_margin(w)
         literal(w, "\$\$\n")
         for line in eachline(IOBuffer(node.literal))
@@ -269,7 +269,7 @@ end
 function write_json(m::Math, ctx, node, enter)
     enter || return
     kind = m.display ? "DisplayMath" : "InlineMath"
-    push_element!(ctx, json_el(ctx, "Math", Any[json_el(ctx, kind), node.literal]))
+    return push_element!(ctx, json_el(ctx, "Math", Any[json_el(ctx, kind), node.literal]))
 end
 
 function write_json(::DisplayMath, ctx, node, enter)
@@ -277,7 +277,7 @@ function write_json(::DisplayMath, ctx, node, enter)
     math_el = json_el(ctx, "Math", Any[json_el(ctx, "DisplayMath"), node.literal])
     # Only wrap in Para when DisplayMath is a top-level block.
     # If already inside a Paragraph, emit the Math inline directly.
-    if node.parent.t isa Paragraph
+    return if node.parent.t isa Paragraph
         push_element!(ctx, math_el)
     else
         push_element!(ctx, json_el(ctx, "Para", Any[math_el]))

--- a/src/extensions/raw.jl
+++ b/src/extensions/raw.jl
@@ -72,8 +72,7 @@ end
 
 const reRawContent = r"^{=([a-z]+)}"
 
-inline_rule(rule::RawContentRule) =
-    Rule(1, "{") do parser, block
+inline_rule(rule::RawContentRule) = Rule(1, "{") do parser, block
     if !isnull(block.last_child) && block.last_child.t isa Code
         m = match(reRawContent, parser)
         if m !== nothing
@@ -88,8 +87,7 @@ inline_rule(rule::RawContentRule) =
     return false
 end
 
-block_modifier(rule::RawContentRule) =
-    Rule(2) do parser, node
+block_modifier(rule::RawContentRule) = Rule(2) do parser, node
     if node.t isa CodeBlock
         m = match(reRawContent, node.t.info)
         m === nothing && return nothing

--- a/src/extensions/raw.jl
+++ b/src/extensions/raw.jl
@@ -13,25 +13,25 @@ struct TypstBlock <: AbstractBlock end
 function Node(::Type{LaTeXInline}, s::AbstractString)
     node = Node(LaTeXInline())
     node.literal = s
-    node
+    return node
 end
 
 function Node(::Type{LaTeXBlock}, s::AbstractString)
     node = Node(LaTeXBlock())
     node.literal = s
-    node
+    return node
 end
 
 function Node(::Type{TypstInline}, s::AbstractString)
     node = Node(TypstInline())
     node.literal = s
-    node
+    return node
 end
 
 function Node(::Type{TypstBlock}, s::AbstractString)
     node = Node(TypstBlock())
     node.literal = s
-    node
+    return node
 end
 
 const RAW_CONTENT_DEFAULTS = Dict(
@@ -63,10 +63,10 @@ is added automatically based on context.
 Default formats: `html`, `latex`, `typst`.
 """
 struct RawContentRule
-    formats::Dict{String,Any}
+    formats::Dict{String, Any}
     function RawContentRule(; formats...)
         return isempty(formats) ? new(RAW_CONTENT_DEFAULTS) :
-               new(Dict("$k" => v for (k, v) in formats))
+            new(Dict("$k" => v for (k, v) in formats))
     end
 end
 
@@ -74,30 +74,30 @@ const reRawContent = r"^{=([a-z]+)}"
 
 inline_rule(rule::RawContentRule) =
     Rule(1, "{") do parser, block
-        if !isnull(block.last_child) && block.last_child.t isa Code
-            m = match(reRawContent, parser)
-            if m !== nothing
-                key = "$(m[1])_inline"
-                if haskey(rule.formats, key)
-                    block.last_child.t = rule.formats[key]()
-                    consume(parser, m)
-                    return true
-                end
+    if !isnull(block.last_child) && block.last_child.t isa Code
+        m = match(reRawContent, parser)
+        if m !== nothing
+            key = "$(m[1])_inline"
+            if haskey(rule.formats, key)
+                block.last_child.t = rule.formats[key]()
+                consume(parser, m)
+                return true
             end
         end
-        return false
     end
+    return false
+end
 
 block_modifier(rule::RawContentRule) =
     Rule(2) do parser, node
-        if node.t isa CodeBlock
-            m = match(reRawContent, node.t.info)
-            m === nothing && return nothing
-            key = "$(m[1])_block"
-            haskey(rule.formats, key) && (node.t = rule.formats[key]())
-        end
-        return nothing
+    if node.t isa CodeBlock
+        m = match(reRawContent, node.t.info)
+        m === nothing && return nothing
+        key = "$(m[1])_block"
+        haskey(rule.formats, key) && (node.t = rule.formats[key]())
     end
+    return nothing
+end
 
 # Raw LaTeX doesn't get displayed in HTML documents.
 write_html(::LaTeXBlock, w, n, en) = nothing
@@ -111,7 +111,7 @@ write_html(::TypstInline, w, n, ent) = nothing
 function write_latex(::LaTeXBlock, w, n, ent)
     cr(w)
     literal(w, n.literal)
-    cr(w)
+    return cr(w)
 end
 write_latex(::LaTeXInline, w, n, ent) = literal(w, n.literal)
 
@@ -121,7 +121,7 @@ write_latex(::TypstInline, w, n, ent) = nothing
 function write_typst(::TypstBlock, w, n, ent)
     cr(w)
     literal(w, n.literal)
-    cr(w)
+    return cr(w)
 end
 write_typst(::TypstInline, w, n, ent) = literal(w, n.literal)
 
@@ -136,7 +136,7 @@ write_term(::LaTeXInline, w, n, ent) = write_term(HtmlInline(), w, n, ent)
 write_term(::TypstBlock, w, n, ent) = write_term(HtmlBlock(), w, n, ent)
 write_term(::TypstInline, w, n, ent) = write_term(HtmlInline(), w, n, ent)
 
-function write_markdown(t::Union{LaTeXBlock,TypstBlock}, w, n, ent)
+function write_markdown(t::Union{LaTeXBlock, TypstBlock}, w, n, ent)
     print_margin(w)
     literal(w, "```{=$(_raw_tag(t))}\n")
     for line in eachline(IOBuffer(n.literal))
@@ -145,16 +145,16 @@ function write_markdown(t::Union{LaTeXBlock,TypstBlock}, w, n, ent)
     end
     print_margin(w)
     literal(w, "```\n")
-    linebreak(w, n)
+    return linebreak(w, n)
 end
 
-function write_markdown(t::Union{LaTeXInline,TypstInline}, w, n, ent)
+function write_markdown(t::Union{LaTeXInline, TypstInline}, w, n, ent)
     num = foldl(eachmatch(r"`+", n.literal); init = 0) do a, b
         max(a, length(b.match))
     end
     literal(w, '`'^(num == 1 ? 2 : 1))
     literal(w, n.literal)
-    literal(w, '`'^(num == 1 ? 2 : 1), "{=$(_raw_tag(t))}")
+    return literal(w, '`'^(num == 1 ? 2 : 1), "{=$(_raw_tag(t))}")
 end
 
 _raw_tag(::LaTeXInline) = "latex"
@@ -164,20 +164,20 @@ _raw_tag(::TypstBlock) = "typst"
 
 function write_json(::LaTeXBlock, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawBlock", Any["latex", node.literal]))
+    return push_element!(ctx, json_el(ctx, "RawBlock", Any["latex", node.literal]))
 end
 
 function write_json(::LaTeXInline, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawInline", Any["latex", node.literal]))
+    return push_element!(ctx, json_el(ctx, "RawInline", Any["latex", node.literal]))
 end
 
 function write_json(::TypstBlock, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawBlock", Any["typst", node.literal]))
+    return push_element!(ctx, json_el(ctx, "RawBlock", Any["typst", node.literal]))
 end
 
 function write_json(::TypstInline, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawInline", Any["typst", node.literal]))
+    return push_element!(ctx, json_el(ctx, "RawInline", Any["typst", node.literal]))
 end

--- a/src/extensions/referencelinks.jl
+++ b/src/extensions/referencelinks.jl
@@ -98,50 +98,50 @@ const REFLINK_STYLES = (:full, :collapsed, :shortcut)
 
 """Reference-style link. Build with `Node(ReferenceLink, children...; dest, label, title="", style=:full)`."""
 function Node(
-    ::Type{ReferenceLink},
-    children...;
-    dest::AbstractString,
-    label::AbstractString,
-    title::AbstractString = "",
-    style::Symbol = :full,
-)
+        ::Type{ReferenceLink},
+        children...;
+        dest::AbstractString,
+        label::AbstractString,
+        title::AbstractString = "",
+        style::Symbol = :full,
+    )
     style in REFLINK_STYLES || error("style must be one of $REFLINK_STYLES")
-    _build(ReferenceLink(dest, title, label, style), children)
+    return _build(ReferenceLink(dest, title, label, style), children)
 end
 
 """Reference-style image. Build with `Node(ReferenceImage, children...; dest, label, title="", style=:full)`."""
 function Node(
-    ::Type{ReferenceImage},
-    children...;
-    dest::AbstractString,
-    label::AbstractString,
-    title::AbstractString = "",
-    style::Symbol = :full,
-)
+        ::Type{ReferenceImage},
+        children...;
+        dest::AbstractString,
+        label::AbstractString,
+        title::AbstractString = "",
+        style::Symbol = :full,
+    )
     style in REFLINK_STYLES || error("style must be one of $REFLINK_STYLES")
-    _build(ReferenceImage(dest, title, label, style), children)
+    return _build(ReferenceImage(dest, title, label, style), children)
 end
 
 """Reference definition. Build with `Node(ReferenceDefinition; label, dest, title="")`."""
 function Node(
-    ::Type{ReferenceDefinition};
-    label::AbstractString,
-    dest::AbstractString,
-    title::AbstractString = "",
-)
-    Node(ReferenceDefinition(label, dest, title))
+        ::Type{ReferenceDefinition};
+        label::AbstractString,
+        dest::AbstractString,
+        title::AbstractString = "",
+    )
+    return Node(ReferenceDefinition(label, dest, title))
 end
 
 """Unresolved reference. Build with `Node(UnresolvedReference, children...; label, style=:shortcut, image=false)`."""
 function Node(
-    ::Type{UnresolvedReference},
-    children...;
-    label::AbstractString,
-    style::Symbol = :shortcut,
-    image::Bool = false,
-)
+        ::Type{UnresolvedReference},
+        children...;
+        label::AbstractString,
+        style::Symbol = :shortcut,
+        image::Bool = false,
+    )
     style in REFLINK_STYLES || error("style must be one of $REFLINK_STYLES")
-    _build(UnresolvedReference(label, style, image), children)
+    return _build(UnresolvedReference(label, style, image), children)
 end
 
 # Inline rule - intercepts reference links before standard LinkRule
@@ -247,8 +247,8 @@ function parse_reference_close_bracket(parser::InlineParser, block::Node)
         dest, title = link
         node = Node(
             is_image ?
-            ReferenceImage(dest, title === nothing ? "" : title, label, style) :
-            ReferenceLink(dest, title === nothing ? "" : title, label, style),
+                ReferenceImage(dest, title === nothing ? "" : title, label, style) :
+                ReferenceLink(dest, title === nothing ? "" : title, label, style),
         )
     end
 
@@ -286,59 +286,59 @@ inline_rule(::ReferenceLinkRule) = Rule(parse_reference_close_bracket, 0.5, "]")
 
 block_rule(::ReferenceLinkRule) =
     Rule(0.5, "[") do parser, container
-        parser.indented && return 0
+    parser.indented && return 0
 
-        ln = rest_from_nonspace(parser)
+    ln = rest_from_nonspace(parser)
 
-        # Match [label]: pattern - label can contain anything except unescaped [ or ]
-        m = match(r"^\[([^\[\]\\]|\\.){1,999}\]:", ln)
-        m === nothing && return 0
+    # Match [label]: pattern - label can contain anything except unescaped [ or ]
+    m = match(r"^\[([^\[\]\\]|\\.){1,999}\]:", ln)
+    m === nothing && return 0
 
-        # Extract label (strip brackets and colon)
-        label_with_brackets = m.match[1:end-1]  # remove trailing :
-        label = chop(label_with_brackets; head = 1, tail = 1)  # remove [ and ]
+    # Extract label (strip brackets and colon)
+    label_with_brackets = m.match[1:(end - 1)]  # remove trailing :
+    label = chop(label_with_brackets; head = 1, tail = 1)  # remove [ and ]
 
-        # Parse rest of line for destination and title
-        rest = SubString(ln, ncodeunits(m.match) + 1)
+    # Parse rest of line for destination and title
+    rest = SubString(ln, ncodeunits(m.match) + 1)
 
-        # Skip leading whitespace
-        rest_stripped = lstrip(rest)
-        isempty(rest_stripped) && return 0  # no destination
+    # Skip leading whitespace
+    rest_stripped = lstrip(rest)
+    isempty(rest_stripped) && return 0  # no destination
 
-        # Use InlineParser to parse destination and title
-        inline_parser = parser.inline_parser
-        inline_parser.buf = String(rest_stripped)
-        seek(inline_parser, 1)
+    # Use InlineParser to parse destination and title
+    inline_parser = parser.inline_parser
+    inline_parser.buf = String(rest_stripped)
+    seek(inline_parser, 1)
 
-        dest = parse_link_destination(inline_parser)
-        dest === nothing && return 0
+    dest = parse_link_destination(inline_parser)
+    dest === nothing && return 0
 
-        # Try to parse title
-        title = ""
-        chomp_ws(inline_parser)
-        if position(inline_parser) > 1
-            t = parse_link_title(inline_parser)
-            t !== nothing && (title = t)
-        end
-
-        # Verify we consumed the meaningful content (allow trailing whitespace)
-        remaining = SubString(inline_parser.buf, position(inline_parser))
-        if !all(isspace, remaining)
-            return 0  # extra content after definition
-        end
-
-        # Create the definition node
-        close_unmatched_blocks(parser)
-        add_child(parser, ReferenceDefinition(label, dest, title), parser.next_nonspace)
-
-        # Add to refmap for inline link resolution (first definition wins)
-        normlabel = normalize_reference(label)
-        haskey(parser.refmap, normlabel) || (parser.refmap[normlabel] = (dest, title))
-
-        # Consume the entire line
-        advance_offset(parser, length(parser.buf) - parser.next_nonspace + 1, false)
-        return 2  # leaf block
+    # Try to parse title
+    title = ""
+    chomp_ws(inline_parser)
+    if position(inline_parser) > 1
+        t = parse_link_title(inline_parser)
+        t !== nothing && (title = t)
     end
+
+    # Verify we consumed the meaningful content (allow trailing whitespace)
+    remaining = SubString(inline_parser.buf, position(inline_parser))
+    if !all(isspace, remaining)
+        return 0  # extra content after definition
+    end
+
+    # Create the definition node
+    close_unmatched_blocks(parser)
+    add_child(parser, ReferenceDefinition(label, dest, title), parser.next_nonspace)
+
+    # Add to refmap for inline link resolution (first definition wins)
+    normlabel = normalize_reference(label)
+    haskey(parser.refmap, normlabel) || (parser.refmap[normlabel] = (dest, title))
+
+    # Consume the entire line
+    advance_offset(parser, length(parser.buf) - parser.next_nonspace + 1, false)
+    return 2  # leaf block
+end
 
 #
 # Writers
@@ -347,7 +347,7 @@ block_rule(::ReferenceLinkRule) =
 # Markdown - output reference style
 
 function write_markdown(ref::ReferenceLink, w, node, ent)
-    if ent
+    return if ent
         literal(w, "[")
     else
         if ref.style === :full
@@ -361,7 +361,7 @@ function write_markdown(ref::ReferenceLink, w, node, ent)
 end
 
 function write_markdown(ref::ReferenceImage, w, node, ent)
-    if ent
+    return if ent
         literal(w, "![")
     else
         if ref.style === :full
@@ -377,7 +377,7 @@ end
 # HTML - same as regular Link/Image
 
 function write_html(ref::ReferenceLink, r, n, ent)
-    if ent
+    return if ent
         attrs = []
         if !(r.format.safe && potentially_unsafe(ref.destination))
             push!(attrs, "href" => escape_xml(ref.destination))
@@ -392,7 +392,7 @@ function write_html(ref::ReferenceLink, r, n, ent)
 end
 
 function write_html(ref::ReferenceImage, r, n, ent)
-    if ent
+    return if ent
         if r.format.disable_tags == 0
             if r.format.safe && potentially_unsafe(ref.destination)
                 literal(r, "<img src=\"\" alt=\"")
@@ -415,16 +415,16 @@ end
 # LaTeX
 
 function write_latex(ref::ReferenceLink, w, node, ent)
-    if ent
+    return if ent
         type, n = startswith(ref.destination, '#') ? ("hyperlink", 1) : ("href", 0)
-        literal(w, "\\$type{$(chop(ref.destination; head=n, tail=0))}{")
+        literal(w, "\\$type{$(chop(ref.destination; head = n, tail = 0))}{")
     else
         literal(w, "}")
     end
 end
 
 function write_latex(ref::ReferenceImage, w, node, ent)
-    if ent
+    return if ent
         cr(w)
         literal(w, "\\begin{figure}\n")
         literal(w, "\\centering\n")
@@ -441,7 +441,7 @@ end
 
 function write_term(ref::ReferenceLink, render, node, enter)
     style = crayon"blue underline"
-    if enter
+    return if enter
         print_literal(render, style)
         push_inline!(render, style)
     else
@@ -452,7 +452,7 @@ end
 
 function write_term(ref::ReferenceImage, render, node, enter)
     style = crayon"green"
-    if enter
+    return if enter
         print_literal(render, style)
         push_inline!(render, style)
     else
@@ -464,7 +464,7 @@ end
 # Typst
 
 function write_typst(ref::ReferenceLink, w, node, ent)
-    if ent
+    return if ent
         literal(w, "#link(", repr(ref.destination), ")[")
     else
         literal(w, "]")
@@ -472,7 +472,7 @@ function write_typst(ref::ReferenceLink, w, node, ent)
 end
 
 function write_typst(ref::ReferenceImage, w, node, ent)
-    if ent
+    return if ent
         literal(w, "#figure(image(", repr(ref.destination), "), caption: [")
     else
         literal(w, "])")
@@ -486,7 +486,7 @@ function write_markdown(def::ReferenceDefinition, w, node, ent)
     literal(w, "[", def.label, "]: ", def.destination)
     isempty(def.title) || literal(w, " \"", escape_markdown_title(def.title), "\"")
     cr(w)
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
 write_html(::ReferenceDefinition, r, n, ent) = nothing
@@ -499,7 +499,7 @@ write_typst(::ReferenceDefinition, w, n, ent) = nothing
 # For shortcut style, we output [text] or ![text] directly
 
 function write_markdown(ref::UnresolvedReference, w, node, ent)
-    if ent
+    return if ent
         # Only use image flag for shortcut style - for full/collapsed, ![ is in preceding Text
         use_image = ref.image && ref.style === :shortcut
         literal(w, use_image ? "![" : "[")
@@ -510,7 +510,7 @@ end
 
 # HTML - output as text (no link)
 function write_html(ref::UnresolvedReference, r, n, ent)
-    if ent
+    return if ent
         use_image = ref.image && ref.style === :shortcut
         literal(r, use_image ? "![" : "[")
     else
@@ -520,7 +520,7 @@ end
 
 # LaTeX - output as text
 function write_latex(ref::UnresolvedReference, w, node, ent)
-    if ent
+    return if ent
         use_image = ref.image && ref.style === :shortcut
         literal(w, use_image ? "![" : "[")
     else
@@ -531,7 +531,7 @@ end
 # Term - output as warning style
 function write_term(ref::UnresolvedReference, render, node, enter)
     style = crayon"red"
-    if enter
+    return if enter
         use_image = ref.image && ref.style === :shortcut
         print_literal(render, style, use_image ? "![" : "[")
         push_inline!(render, style)
@@ -543,7 +543,7 @@ end
 
 # Typst - output as text
 function write_typst(ref::UnresolvedReference, w, node, ent)
-    if ent
+    return if ent
         use_image = ref.image && ref.style === :shortcut
         literal(w, use_image ? "![" : "[")
     else
@@ -554,7 +554,7 @@ end
 # JSON - same as regular Link/Image
 
 function write_json(ref::ReferenceLink, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -565,7 +565,7 @@ function write_json(ref::ReferenceLink, ctx, node, enter)
 end
 
 function write_json(ref::ReferenceImage, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -578,7 +578,7 @@ end
 write_json(::ReferenceDefinition, ctx, node, enter) = nothing
 
 function write_json(ref::UnresolvedReference, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else

--- a/src/extensions/referencelinks.jl
+++ b/src/extensions/referencelinks.jl
@@ -284,8 +284,7 @@ inline_rule(::ReferenceLinkRule) = Rule(parse_reference_close_bracket, 0.5, "]")
 
 # Block rule - captures reference definitions in place
 
-block_rule(::ReferenceLinkRule) =
-    Rule(0.5, "[") do parser, container
+block_rule(::ReferenceLinkRule) = Rule(0.5, "[") do parser, container
     parser.indented && return 0
 
     ln = rest_from_nonspace(parser)

--- a/src/extensions/shortcodes.jl
+++ b/src/extensions/shortcodes.jl
@@ -212,8 +212,7 @@ end
 # Inline rule
 #
 
-inline_rule(rule::ShortcodeRule) =
-    Rule(1, string(first(rule.open))) do p, block
+inline_rule(rule::ShortcodeRule) = Rule(1, string(first(rule.open))) do p, block
     result = _try_parse_shortcode(p, rule)
     result === nothing && return false
     name, args, kwargs, raw = result
@@ -231,8 +230,7 @@ end
 # Block modifier
 #
 
-block_modifier(rule::ShortcodeRule) =
-    Rule(2) do parser, node
+block_modifier(rule::ShortcodeRule) = Rule(2) do parser, node
     node.t isa Paragraph || return nothing
     result = _is_solo_shortcode(node.literal, rule)
     result === nothing && return nothing

--- a/src/extensions/shortcodes.jl
+++ b/src/extensions/shortcodes.jl
@@ -6,7 +6,7 @@
 struct Shortcode <: AbstractInline
     name::String
     args::Vector{String}
-    kwargs::Vector{Pair{String,String}}
+    kwargs::Vector{Pair{String, String}}
     raw::String
 end
 
@@ -14,7 +14,7 @@ end
 struct ShortcodeBlock <: AbstractBlock
     name::String
     args::Vector{String}
-    kwargs::Vector{Pair{String,String}}
+    kwargs::Vector{Pair{String, String}}
     raw::String
 end
 
@@ -26,14 +26,14 @@ end
 struct ShortcodeContext
     source::String
     sourcepos::SourcePos
-    meta::Dict{String,Any}
+    meta::Dict{String, Any}
 end
 
 function _shortcode_context(parser::Parser, sourcepos::SourcePos)
-    ShortcodeContext(
+    return ShortcodeContext(
         getmeta(parser.doc, "source", ""),
         sourcepos,
-        something(parser.doc.meta, Dict{String,Any}()),
+        something(parser.doc.meta, Dict{String, Any}()),
     )
 end
 
@@ -42,10 +42,10 @@ function _shortcode_context(block::Node)
     while !isnull(doc.parent)
         doc = doc.parent
     end
-    ShortcodeContext(
+    return ShortcodeContext(
         getmeta(doc, "source", ""),
         block.sourcepos,
-        something(doc.meta, Dict{String,Any}()),
+        something(doc.meta, Dict{String, Any}()),
     )
 end
 
@@ -76,13 +76,13 @@ Block (standalone): {{< pagebreak >}}
 struct ShortcodeRule
     open::String
     close::String
-    handlers::Dict{String,Function}
+    handlers::Dict{String, Function}
     function ShortcodeRule(;
-        open::String = "{{<",
-        close::String = ">}}",
-        handlers::Dict{String,Function} = Dict{String,Function}(),
-    )
-        new(open, close, handlers)
+            open::String = "{{<",
+            close::String = ">}}",
+            handlers::Dict{String, Function} = Dict{String, Function}(),
+        )
+        return new(open, close, handlers)
     end
 end
 
@@ -152,7 +152,7 @@ end
 """Parse shortcode args string into positional args and named kwargs."""
 function _parse_shortcode_args(s::AbstractString)
     args = String[]
-    kwargs = Pair{String,String}[]
+    kwargs = Pair{String, String}[]
     isempty(s) && return (args, kwargs)
     buf = IOBuffer()
     in_quote = nothing  # nothing, '"', or '\''
@@ -189,7 +189,7 @@ end
 function _flush_shortcode_token!(buf::IOBuffer, args, kwargs, eq_pos)
     position(buf) == 0 && return
     token = String(take!(buf))
-    if eq_pos > 1
+    return if eq_pos > 1
         key = token[1:prevind(token, eq_pos)]
         val = token[nextind(token, eq_pos):end]
         push!(kwargs, key => val)
@@ -214,18 +214,18 @@ end
 
 inline_rule(rule::ShortcodeRule) =
     Rule(1, string(first(rule.open))) do p, block
-        result = _try_parse_shortcode(p, rule)
-        result === nothing && return false
-        name, args, kwargs, raw = result
-        handler = get(rule.handlers, name, nothing)
-        if handler !== nothing
-            ctx = _shortcode_context(block)
-            append_child(block, handler(name, args, kwargs, ctx))
-        else
-            append_child(block, Node(Shortcode(name, args, kwargs, raw)))
-        end
-        return true
+    result = _try_parse_shortcode(p, rule)
+    result === nothing && return false
+    name, args, kwargs, raw = result
+    handler = get(rule.handlers, name, nothing)
+    if handler !== nothing
+        ctx = _shortcode_context(block)
+        append_child(block, handler(name, args, kwargs, ctx))
+    else
+        append_child(block, Node(Shortcode(name, args, kwargs, raw)))
     end
+    return true
+end
 
 #
 # Block modifier
@@ -233,28 +233,28 @@ inline_rule(rule::ShortcodeRule) =
 
 block_modifier(rule::ShortcodeRule) =
     Rule(2) do parser, node
-        node.t isa Paragraph || return nothing
-        result = _is_solo_shortcode(node.literal, rule)
-        result === nothing && return nothing
-        name, args, kwargs, raw = result
+    node.t isa Paragraph || return nothing
+    result = _is_solo_shortcode(node.literal, rule)
+    result === nothing && return nothing
+    name, args, kwargs, raw = result
 
-        handler = get(rule.handlers, name, nothing)
-        if handler !== nothing
-            ctx = _shortcode_context(parser, node.sourcepos)
-            replacement = handler(name, args, kwargs, ctx)
-            node.t = replacement.t
-            node.literal = replacement.literal
-            while !isnull(replacement.first_child)
-                child = replacement.first_child
-                unlink(child)
-                append_child(node, child)
-            end
-        else
-            node.t = ShortcodeBlock(name, args, kwargs, raw)
-            node.literal = ""
+    handler = get(rule.handlers, name, nothing)
+    if handler !== nothing
+        ctx = _shortcode_context(parser, node.sourcepos)
+        replacement = handler(name, args, kwargs, ctx)
+        node.t = replacement.t
+        node.literal = replacement.literal
+        while !isnull(replacement.first_child)
+            child = replacement.first_child
+            unlink(child)
+            append_child(node, child)
         end
-        return nothing
+    else
+        node.t = ShortcodeBlock(name, args, kwargs, raw)
+        node.literal = ""
     end
+    return nothing
+end
 
 #
 # Writers
@@ -271,35 +271,35 @@ write_markdown(sc::Shortcode, w, n, ent) = literal(w, sc.raw)
 function write_html(sc::ShortcodeBlock, w, n, ent)
     cr(w)
     literal(w, sc.raw)
-    cr(w)
+    return cr(w)
 end
 function write_latex(sc::ShortcodeBlock, w, n, ent)
     cr(w)
     literal(w, sc.raw)
-    cr(w)
+    return cr(w)
 end
 function write_typst(sc::ShortcodeBlock, w, n, ent)
     cr(w)
     literal(w, sc.raw)
-    cr(w)
+    return cr(w)
 end
 function write_term(sc::ShortcodeBlock, w, n, ent)
     print_margin(w)
-    print_literal(w, sc.raw, "\n")
+    return print_literal(w, sc.raw, "\n")
 end
 function write_markdown(sc::ShortcodeBlock, w, n, ent)
     print_margin(w)
     literal(w, sc.raw)
     cr(w)
-    linebreak(w, n)
+    return linebreak(w, n)
 end
 
 # --- JSON ---
 function write_json(sc::Shortcode, ctx, n, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawInline", Any["shortcode", sc.raw]))
+    return push_element!(ctx, json_el(ctx, "RawInline", Any["shortcode", sc.raw]))
 end
 function write_json(sc::ShortcodeBlock, ctx, n, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawBlock", Any["shortcode", sc.raw]))
+    return push_element!(ctx, json_el(ctx, "RawBlock", Any["shortcode", sc.raw]))
 end

--- a/src/extensions/strikethrough.jl
+++ b/src/extensions/strikethrough.jl
@@ -38,16 +38,16 @@ write_html(::Strikethrough, r, n, ent) =
 
 function write_latex(::Strikethrough, w, n, ent)
     # Requires \usepackage{soul} or \usepackage{ulem}
-    print(w.buffer, ent ? "\\sout{" : "}")
+    return print(w.buffer, ent ? "\\sout{" : "}")
 end
 
 function write_typst(::Strikethrough, w, n, ent)
-    print(w.buffer, ent ? "#strike[" : "]")
+    return print(w.buffer, ent ? "#strike[" : "]")
 end
 
 function write_term(::Strikethrough, w, n, ent)
     style = crayon"strikethrough"
-    if ent
+    return if ent
         print_literal(w, style)
         push_inline!(w, style)
     else
@@ -57,11 +57,11 @@ function write_term(::Strikethrough, w, n, ent)
 end
 
 function write_markdown(::Strikethrough, w, n, ent)
-    literal(w, "~~")
+    return literal(w, "~~")
 end
 
 function write_json(::Strikethrough, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else

--- a/src/extensions/subscript.jl
+++ b/src/extensions/subscript.jl
@@ -35,23 +35,23 @@ write_html(::Subscript, r, n, ent) =
     tag(r, ent ? "sub" : "/sub", ent ? attributes(r, n) : [])
 
 function write_latex(::Subscript, w, n, ent)
-    print(w.buffer, ent ? "\\textsubscript{" : "}")
+    return print(w.buffer, ent ? "\\textsubscript{" : "}")
 end
 
 function write_typst(::Subscript, w, n, ent)
-    print(w.buffer, ent ? "#sub[" : "]")
+    return print(w.buffer, ent ? "#sub[" : "]")
 end
 
 function write_term(::Subscript, w, n, ent)
-    ent ? push!(w.format.text_context, :subscript) : pop!(w.format.text_context)
+    return ent ? push!(w.format.text_context, :subscript) : pop!(w.format.text_context)
 end
 
 function write_markdown(::Subscript, w, n, ent)
-    literal(w, "~")
+    return literal(w, "~")
 end
 
 function write_json(::Subscript, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else

--- a/src/extensions/superscript.jl
+++ b/src/extensions/superscript.jl
@@ -37,23 +37,23 @@ write_html(::Superscript, r, n, ent) =
     tag(r, ent ? "sup" : "/sup", ent ? attributes(r, n) : [])
 
 function write_latex(::Superscript, w, n, ent)
-    print(w.buffer, ent ? "\\textsuperscript{" : "}")
+    return print(w.buffer, ent ? "\\textsuperscript{" : "}")
 end
 
 function write_typst(::Superscript, w, n, ent)
-    print(w.buffer, ent ? "#super[" : "]")
+    return print(w.buffer, ent ? "#super[" : "]")
 end
 
 function write_term(::Superscript, w, n, ent)
-    ent ? push!(w.format.text_context, :superscript) : pop!(w.format.text_context)
+    return ent ? push!(w.format.text_context, :superscript) : pop!(w.format.text_context)
 end
 
 function write_markdown(::Superscript, w, n, ent)
-    literal(w, "^")
+    return literal(w, "^")
 end
 
 function write_json(::Superscript, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else

--- a/src/extensions/tables.jl
+++ b/src/extensions/tables.jl
@@ -187,8 +187,7 @@ block_rule(::TableRule) = Rule(gfm_table, 0.5, "|")
 
 struct TablePipe <: AbstractInline end
 
-inline_rule(rule::TableRule) =
-    Rule(0, "|") do parser, block
+inline_rule(rule::TableRule) = Rule(0, "|") do parser, block
     block.t isa TableRow || return false
     @assert read(parser, Char) == '|'
     eof(parser) && return true # Skip last pipe.
@@ -200,8 +199,7 @@ end
 
 # Low priority since this *must* happen after nested structure of emphasis and
 # links is determined. 100 should do fine.
-inline_modifier(rule::TableRule) =
-    Rule(100) do parser, block
+inline_modifier(rule::TableRule) = Rule(100) do parser, block
     block.t isa TableRow || return
     block.parent.parent.t isa Table || return
     isheader = block.parent.t isa TableHeader

--- a/src/extensions/tables.jl
+++ b/src/extensions/tables.jl
@@ -14,11 +14,11 @@ end
 continue_(::Table, parser::Parser, ::Node) = parser.blank ? 1 : 0
 
 function Node(
-    ::Type{Table},
-    header::Node,
-    body_rows::Node...;
-    align::Vector{Symbol} = Symbol[],
-)
+        ::Type{Table},
+        header::Node,
+        body_rows::Node...;
+        align::Vector{Symbol} = Symbol[],
+    )
     spec =
         isempty(align) ?
         fill(
@@ -33,7 +33,7 @@ function Node(
         append_child(body, row)
     end
     append_child(node, body)
-    node
+    return node
 end
 
 function count_cells(header::Node)
@@ -43,7 +43,7 @@ function count_cells(header::Node)
         count += 1
         cell = cell.nxt
     end
-    count
+    return count
 end
 
 """Table header section containing one row."""
@@ -52,7 +52,7 @@ struct TableHeader <: TableComponent end
 function Node(::Type{TableHeader}, row::Node)
     node = Node(TableHeader())
     append_child(node, row)
-    node
+    return node
 end
 
 """Table body section containing data rows."""
@@ -89,16 +89,16 @@ end
 contains_inlines(::TableCell) = true
 
 function Node(
-    ::Type{TableCell},
-    children...;
-    align::Symbol = :left,
-    header::Bool = false,
-    column::Int = 1,
-    rowspan::Int = 1,
-    colspan::Int = 1,
-)
+        ::Type{TableCell},
+        children...;
+        align::Symbol = :left,
+        header::Bool = false,
+        column::Int = 1,
+        rowspan::Int = 1,
+        colspan::Int = 1,
+    )
     tc = TableCell(align, header, column, rowspan, colspan)
-    _build(tc, children)
+    return _build(tc, children)
 end
 
 function gfm_table(parser::Parser, container::Node)
@@ -150,7 +150,7 @@ valid_table_row(str) = startswith(str, '|')
 valid_table_spec(str) = all(c -> c in "|-: ", str)
 
 function parse_table_spec(str)
-    map(eachmatch(r"\|([ ]*[: ]?[-]+[ :]?[ ]*)\|", str; overlap = true)) do match
+    return map(eachmatch(r"\|([ ]*[: ]?[-]+[ :]?[ ]*)\|", str; overlap = true)) do match
         str = strip(match[1])
         left, right = str[1] === ':', str[end] === ':'
         center = left && right
@@ -189,68 +189,68 @@ struct TablePipe <: AbstractInline end
 
 inline_rule(rule::TableRule) =
     Rule(0, "|") do parser, block
-        block.t isa TableRow || return false
-        @assert read(parser, Char) == '|'
-        eof(parser) && return true # Skip last pipe.
-        pipe = Node(TablePipe())
-        append_child(block, pipe)
-        push!(rule.pipes, pipe)
-        return true
-    end
+    block.t isa TableRow || return false
+    @assert read(parser, Char) == '|'
+    eof(parser) && return true # Skip last pipe.
+    pipe = Node(TablePipe())
+    append_child(block, pipe)
+    push!(rule.pipes, pipe)
+    return true
+end
 
 # Low priority since this *must* happen after nested structure of emphasis and
 # links is determined. 100 should do fine.
 inline_modifier(rule::TableRule) =
     Rule(100) do parser, block
-        block.t isa TableRow || return
-        block.parent.parent.t isa Table || return
-        isheader = block.parent.t isa TableHeader
-        spec = block.parent.parent.t.spec
-        max_cols = length(spec)
-        col = 1
-        cells = Node[]
-        while !isempty(rule.pipes)
-            pipe = popfirst!(rule.pipes)
-            if pipe.parent === block
-                # Top-level pipe must be replaced with a table cell containing
-                # everything up until the next pipe.
-                cell = Node(TableCell(spec[min(col, max_cols)], isheader, col, 1, 1))
-                n = pipe.nxt
-                elems = Node[]
-                # Find all nodes between this pipe and the next.
-                while !isnull(n) && !(n.t isa TablePipe)
-                    push!(elems, n)
-                    n = n.nxt
-                end
-                total = length(elems)
-                for (nth, elem) in enumerate(elems)
-                    # Strip surronding whitespace in each cell.
-                    lit = elem.literal
-                    lit = (nth === 1 && elem.t isa Text) ? lstrip(lit) : lit
-                    lit = (nth === total && elem.t isa Text) ? rstrip(lit) : lit
-                    elem.literal = lit
-                    append_child(cell, elem)
-                end
-                push!(cells, cell)
-                unlink(pipe)
-                col += 1
-            else
-                # Replace nested pipes with text literals since they can't
-                # demarcate a cell boarder.
-                pipe.t = Text()
-                pipe.literal = "|"
+    block.t isa TableRow || return
+    block.parent.parent.t isa Table || return
+    isheader = block.parent.t isa TableHeader
+    spec = block.parent.parent.t.spec
+    max_cols = length(spec)
+    col = 1
+    cells = Node[]
+    while !isempty(rule.pipes)
+        pipe = popfirst!(rule.pipes)
+        if pipe.parent === block
+            # Top-level pipe must be replaced with a table cell containing
+            # everything up until the next pipe.
+            cell = Node(TableCell(spec[min(col, max_cols)], isheader, col, 1, 1))
+            n = pipe.nxt
+            elems = Node[]
+            # Find all nodes between this pipe and the next.
+            while !isnull(n) && !(n.t isa TablePipe)
+                push!(elems, n)
+                n = n.nxt
             end
-        end
-        if length(cells) < max_cols
-            # Add addtional cells in this row is below number in spec.
-            extra = (length(cells)+1):max_cols
-            append!(cells, (Node(TableCell(:left, isheader, n, 1, 1)) for n in extra))
-        end
-        for (nth, cell) in enumerate(cells)
-            # Drop additional cells if they are longer that the spec.
-            nth ≤ length(spec) ? append_child(block, cell) : unlink(cell)
+            total = length(elems)
+            for (nth, elem) in enumerate(elems)
+                # Strip surronding whitespace in each cell.
+                lit = elem.literal
+                lit = (nth === 1 && elem.t isa Text) ? lstrip(lit) : lit
+                lit = (nth === total && elem.t isa Text) ? rstrip(lit) : lit
+                elem.literal = lit
+                append_child(cell, elem)
+            end
+            push!(cells, cell)
+            unlink(pipe)
+            col += 1
+        else
+            # Replace nested pipes with text literals since they can't
+            # demarcate a cell boarder.
+            pipe.t = Text()
+            pipe.literal = "|"
         end
     end
+    if length(cells) < max_cols
+        # Add addtional cells in this row is below number in spec.
+        extra = (length(cells) + 1):max_cols
+        append!(cells, (Node(TableCell(:left, isheader, n, 1, 1)) for n in extra))
+    end
+    for (nth, cell) in enumerate(cells)
+        # Drop additional cells if they are longer that the spec.
+        nth ≤ length(spec) ? append_child(block, cell) : unlink(cell)
+    end
+end
 
 #
 # Writers
@@ -266,7 +266,7 @@ write_html(::TableRow, rend, node, enter) = tag(rend, enter ? "tr" : "/tr")
 
 function write_html(cell::TableCell, rend, node, enter)
     tag_name = cell.header ? "th" : "td"
-    if enter
+    return if enter
         attrs = ["align" => string(cell.align)]
         cell.rowspan > 1 && push!(attrs, "rowspan" => string(cell.rowspan))
         cell.colspan > 1 && push!(attrs, "colspan" => string(cell.colspan))
@@ -279,7 +279,7 @@ end
 # LaTeX
 
 function write_latex(::TableHeader, rend, node, enter)
-    if enter
+    return if enter
         println(rend.buffer, "\\hline")
     else
         println(rend.buffer, "\\hline")
@@ -288,7 +288,7 @@ function write_latex(::TableHeader, rend, node, enter)
 end
 
 function write_latex(::TableBody, rend, node, enter)
-    if !enter
+    return if !enter
         println(rend.buffer, "\\hline")
     end
 end
@@ -296,7 +296,7 @@ end
 write_latex(::TableRows, rend, node, enter) = nothing
 
 function write_latex(::TableFoot, rend, node, enter)
-    if enter
+    return if enter
         println(rend.buffer, "\\hline")
     else
         println(rend.buffer, "\\endlastfoot")
@@ -304,11 +304,11 @@ function write_latex(::TableFoot, rend, node, enter)
 end
 
 function write_latex(::TableRow, rend, node, enter)
-    enter ? nothing : println(rend.buffer, "\\tabularnewline")
+    return enter ? nothing : println(rend.buffer, "\\tabularnewline")
 end
 
 function write_latex(::TableCell, rend, node, enter)
-    if !enter && node.parent.last_child !== node
+    return if !enter && node.parent.last_child !== node
         print(rend.buffer, " & ")
     end
 end
@@ -316,7 +316,7 @@ end
 # Typst
 
 function write_typst(::TableHeader, rend, node, enter)
-    if enter
+    return if enter
         println(rend.buffer, "table.header(")
     else
         println(rend.buffer, "),")
@@ -326,7 +326,7 @@ end
 write_typst(::TableBody, rend, node, enter) = nothing
 write_typst(::TableRows, rend, node, enter) = nothing
 function write_typst(::TableFoot, rend, node, enter)
-    if enter
+    return if enter
         println(rend.buffer, "table.footer(")
     else
         println(rend.buffer, "),")
@@ -334,13 +334,13 @@ function write_typst(::TableFoot, rend, node, enter)
 end
 
 function write_typst(::TableRow, rend, node, enter)
-    if !enter
+    return if !enter
         println(rend.buffer)
     end
 end
 
 function write_typst(cell::TableCell, rend, node, enter)
-    if enter
+    return if enter
         if cell.colspan > 1 || cell.rowspan > 1
             parts = String[]
             cell.colspan > 1 && push!(parts, "colspan: $(cell.colspan)")
@@ -410,7 +410,7 @@ function write_term(cell::TableCell, rend, node, enter)
     if haskey(rend.context, :widths)
         widths = rend.context[:widths]
         col_w = widths[cell.column]
-        for i = cell.column+1:min(cell.column + cell.colspan - 1, length(widths))
+        for i in (cell.column + 1):min(cell.column + cell.colspan - 1, length(widths))
             col_w += 3 + widths[i]  # " │ " separator + next column width
         end
         pad = col_w - rend.context[:cells][node]
@@ -505,7 +505,7 @@ write_json(::TableRows, ctx, node, enter) = nothing
 write_json(::TableFoot, ctx, node, enter) = nothing
 
 function write_json(::TableRow, ctx, node, enter)
-    if enter
+    return if enter
         cells = Any[]
         push_container!(ctx, cells)
     else
@@ -516,7 +516,7 @@ function write_json(::TableRow, ctx, node, enter)
         section = node.parent
         section.t isa TableRows && (section = section.parent)
         if section.t isa TableHeader
-            push!(ctx.stack[end-1], row)
+            push!(ctx.stack[end - 1], row)
         else
             push!(ctx.stack[end], row)
         end
@@ -524,7 +524,7 @@ function write_json(::TableRow, ctx, node, enter)
 end
 
 function write_json(cell::TableCell, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -547,7 +547,7 @@ write_json(::TablePipe, ctx, node, enter) = nothing
 _term_visible_length(s) = textwidth(replace(s, r"\e\[[0-9]+(?:;[0-9]+)*m" => ""))
 
 function calculate_columns_widths(width_func, table, node)
-    cells, widths = Dict{Node,Int}(), ones(Int, length(table.spec))
+    cells, widths = Dict{Node, Int}(), ones(Int, length(table.spec))
     index = 0
     for (n, enter) in node
         if enter

--- a/src/extensions/tables_common.jl
+++ b/src/extensions/tables_common.jl
@@ -1,12 +1,12 @@
 # Shared writers for Table and GridTable (both have a `spec` field).
 
-const AnyTable = Union{Table,GridTable}
+const AnyTable = Union{Table, GridTable}
 
 write_html(::AnyTable, rend, node, enter) =
     tag(rend, enter ? "table" : "/table", enter ? attributes(rend, node) : [])
 
 function write_latex(t::AnyTable, rend, node, enter)
-    if enter
+    return if enter
         print(rend.buffer, "\\begin{longtable}[]{@{}")
         join(rend.buffer, (string(a)[1] for a in t.spec))
         println(rend.buffer, "@{}}")
@@ -20,11 +20,11 @@ function _count_header_rows(header_node)
     for (node, enter) in header_node
         enter && node.t isa TableRow && (n += 1)
     end
-    n
+    return n
 end
 
 function write_typst(t::AnyTable, rend, node, enter)
-    if enter
+    return if enter
         align = "align: (" * join(t.spec, ", ") * ")"
         columns = "columns: $(length(t.spec))"
         parts = ["$align", "$columns"]
@@ -39,7 +39,7 @@ function write_typst(t::AnyTable, rend, node, enter)
 end
 
 function write_json(t::AnyTable, ctx, node, enter)
-    if enter
+    return if enter
         colspecs = Any[]
         for align in t.spec
             a =

--- a/src/extensions/tasklist.jl
+++ b/src/extensions/tasklist.jl
@@ -10,7 +10,7 @@ end
 
 function Node(::Type{TaskItem}, children...; checked::Bool = false)
     item = TaskItem(ListData(), checked)
-    _build(item, children)
+    return _build(item, children)
 end
 
 is_container(::TaskItem) = true
@@ -35,25 +35,25 @@ struct TaskListRule end
 
 block_modifier(::TaskListRule) =
     Rule(50) do parser, block
-        if block.t isa Item
-            child = block.first_child
-            if !isnull(child) && child.t isa Paragraph
-                m = match(r"^\[([ xX])\]\s?", child.literal)
-                if m !== nothing
-                    block.t = TaskItem(block.t.list_data, m[1] != " ")
-                    child.literal = child.literal[length(m.match)+1:end]
-                end
+    if block.t isa Item
+        child = block.first_child
+        if !isnull(child) && child.t isa Paragraph
+            m = match(r"^\[([ xX])\]\s?", child.literal)
+            if m !== nothing
+                block.t = TaskItem(block.t.list_data, m[1] != " ")
+                child.literal = child.literal[(length(m.match) + 1):end]
             end
         end
-        return nothing
     end
+    return nothing
+end
 
 #
 # Writers
 #
 
 function write_html(t::TaskItem, r, n, ent)
-    if ent
+    return if ent
         checkbox =
             t.checked ? "<input type=\"checkbox\" disabled checked> " :
             "<input type=\"checkbox\" disabled> "
@@ -66,7 +66,7 @@ function write_html(t::TaskItem, r, n, ent)
 end
 
 function write_term(t::TaskItem, render, node, enter)
-    if enter
+    return if enter
         checkbox = t.checked ? "☑ " : "☐ "
         if t.list_data.type === :ordered
             number = string(render.format.list_item_number[end], ". ")
@@ -89,11 +89,11 @@ function write_latex(t::TaskItem, w, node, ent)
         checkbox = t.checked ? "\$\\boxtimes\$" : "\$\\square\$"
         literal(w, "\\item[$checkbox]")
     end
-    cr(w)
+    return cr(w)
 end
 
 function write_typst(t::TaskItem, w, node, enter)
-    if enter
+    return if enter
         checkbox = t.checked ? "☑ " : "☐ "
         if t.list_data.type === :ordered
             number = lpad(string(w.format.list_item_number[end], ". "), 4, " ")
@@ -111,7 +111,7 @@ function write_typst(t::TaskItem, w, node, enter)
 end
 
 function write_markdown(t::TaskItem, w, node, enter)
-    if enter
+    return if enter
         checkbox = t.checked ? "[x] " : "[ ] "
         if t.list_data.type === :ordered
             number = lpad(string(w.format.list_item_number[end], ". "), 4, " ")
@@ -132,7 +132,7 @@ end
 
 # TaskItem is like Item but with checkbox prepended to first paragraph.
 function write_json(t::TaskItem, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else

--- a/src/extensions/tasklist.jl
+++ b/src/extensions/tasklist.jl
@@ -33,8 +33,7 @@ interactive checkboxes in HTML output.
 """
 struct TaskListRule end
 
-block_modifier(::TaskListRule) =
-    Rule(50) do parser, block
+block_modifier(::TaskListRule) = Rule(50) do parser, block
     if block.t isa Item
         child = block.first_child
         if !isnull(child) && child.t isa Paragraph

--- a/src/parsers.jl
+++ b/src/parsers.jl
@@ -26,7 +26,7 @@ trypeek(p::AbstractParser, ::Type{UInt8}, default = nothing) =
 trypeek(p::AbstractParser, ::Type{Char}, default = nothing) =
     get(String(p.buf), thisind(p), default)
 
-function Base.read(p::AbstractParser, ::Type{T}) where {T<:Union{Char,UInt8}}
+function Base.read(p::AbstractParser, ::Type{T}) where {T <: Union{Char, UInt8}}
     obj = peek(p, T)
     seek(p, nextind(p))
     return obj
@@ -46,8 +46,8 @@ or(::Nothing, default) = default
 prev(p::AbstractParser, ::Type{Char}) = String(p.buf)[prevind(p)]
 next(p::AbstractParser, ::Type{Char}) = String(p.buf)[nextind(p)]
 
-prev(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p)-1]
-next(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p)+1]
+prev(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p) - 1]
+next(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p) + 1]
 
 tryprev(p::AbstractParser, ::Type{Char}, default = nothing) =
     get(String(p.buf), prevind(p), default)

--- a/src/parsers/blocks.jl
+++ b/src/parsers/blocks.jl
@@ -59,7 +59,7 @@ Equivalent to chaining [`enable!`](@ref) and [`disable!`](@ref) calls.
 """
 mutable struct Parser <: AbstractParser
     doc::Node
-    block_starts::Dict{Char,Vector{Function}}
+    block_starts::Dict{Char, Vector{Function}}
     tip::Node
     oldtip::Node
     buf::String
@@ -75,12 +75,12 @@ mutable struct Parser <: AbstractParser
     partially_consumed_tab::Bool
     all_closed::Bool
     last_matched_container::Node
-    refmap::Dict{String,Tuple{String,String}}
+    refmap::Dict{String, Tuple{String, String}}
     last_line_length::Int
     inline_parser::InlineParser
     rules::Vector{Any}
     modifiers::Vector{Function}
-    priorities::IdDict{Function,Float64}
+    priorities::IdDict{Function, Float64}
 
     function Parser(; enable::Vector = [], disable::Vector = [])
         parser = new()
@@ -106,7 +106,7 @@ mutable struct Parser <: AbstractParser
         parser.inline_parser = InlineParser()
         parser.rules = []
         parser.modifiers = Function[]
-        parser.priorities = IdDict{Function,Float64}()
+        parser.priorities = IdDict{Function, Float64}()
 
         # Enable the standard CommonMark rule set.
         enable!(parser, COMMONMARK_BLOCK_RULES)
@@ -134,11 +134,11 @@ function ends_with_blank_line(block::Node)
             return true
         end
         if !block.last_line_checked && (
-            block.t isa List ||
-            block.t isa Item ||
-            block.t isa DefinitionList ||
-            block.t isa DefinitionDescription
-        )
+                block.t isa List ||
+                    block.t isa Item ||
+                    block.t isa DefinitionList ||
+                    block.t isa DefinitionDescription
+            )
             block.last_line_checked = true
             block = block.last_child
         else
@@ -161,7 +161,7 @@ can_contain(::Document, t) = !(t isa Item)
 function Node(::Type{Document}, children...)
     node = _build(Document(), children)
     _heal_footnotes!(node)
-    node
+    return node
 end
 
 function _heal_footnotes!(doc::Node)
@@ -181,6 +181,7 @@ function _heal_footnotes!(doc::Node)
             n.t = FootnoteLink(n.t.id, rule)
         end
     end
+    return
 end
 
 include("blocks/lists.jl")
@@ -218,12 +219,12 @@ function add_line(parser::Parser)
     if parser.partially_consumed_tab
         parser.pos += 1
         chars_to_tab = 4 - (parser.column % 4)
-        for _ = 1:chars_to_tab
+        for _ in 1:chars_to_tab
             write(buf, ' ')
         end
     end
     write(buf, SubString(parser.buf, parser.pos))
-    write(buf, '\n')
+    return write(buf, '\n')
 end
 
 function add_child(parser::Parser, tag::AbstractContainer, offset::Integer)
@@ -271,13 +272,13 @@ function find_next_nonspace(parser::Parser)
     parser.next_nonspace = i
     parser.next_nonspace_column = cols
     parser.indent = parser.next_nonspace_column - parser.column
-    parser.indented = parser.indent ≥ CODE_INDENT
+    return parser.indented = parser.indent ≥ CODE_INDENT
 end
 
 function advance_next_nonspace(parser::Parser)
     parser.pos = parser.next_nonspace
     parser.column = parser.next_nonspace_column
-    parser.partially_consumed_tab = false
+    return parser.partially_consumed_tab = false
 end
 
 function advance_offset(parser::Parser, count::Integer, columns::Bool)
@@ -307,6 +308,7 @@ function advance_offset(parser::Parser, count::Integer, columns::Bool)
         end
         c = get(buf, parser.pos, '\0')
     end
+    return
 end
 
 advance_to_end(parser::Parser) = advance_offset(parser, typemax(Int), false)
@@ -319,9 +321,9 @@ peek_nonspace(p::Parser, default = '\0') = get(p.buf, p.next_nonspace, default)
     t isa BlockQuote && return true
     t isa CodeBlock && return (t::CodeBlock).is_fenced
     t isa Item && return isnull(container.first_child) &&
-           container.sourcepos[1][1] == parser.line_number
+        container.sourcepos[1][1] == parser.line_number
     t isa DefinitionDescription && return isnull(container.first_child) &&
-           container.sourcepos[1][1] == parser.line_number
+        container.sourcepos[1][1] == parser.line_number
     return false
 end
 
@@ -518,6 +520,7 @@ function process_inlines(parser::Parser, block::Node)
             end
         end
     end
+    return
 end
 
 contains_inlines(t) = false
@@ -528,7 +531,7 @@ function parse(parser::Parser, my_input::IO; kws...)
     parser.doc = Node(Document(), ((1, 1), (0, 0)))
     isempty(kws) || mergemeta!(parser.doc, Dict(string(k) => v for (k, v) in kws))
     parser.tip = parser.doc
-    parser.refmap = Dict{String,Tuple{String,String}}()
+    parser.refmap = Dict{String, Tuple{String, String}}()
     parser.line_number = getmeta(parser.doc, "line", 1) - 1
     parser.last_line_length = 0
     parser.pos = 1

--- a/src/parsers/blocks/codeblocks.jl
+++ b/src/parsers/blocks/codeblocks.jl
@@ -18,13 +18,13 @@ function continue_(::CodeBlock, parser::Parser, container::Node)
     indent = parser.indent
     if cb.is_fenced
         m =
-            if indent <= 3 &&
-               length(ln) >= parser.next_nonspace + 1 &&
-               ln[parser.next_nonspace] == cb.fence_char
-                Base.match(reClosingCodeFence, SubString(ln, parser.next_nonspace))
-            else
-                nothing
-            end
+        if indent <= 3 &&
+                length(ln) >= parser.next_nonspace + 1 &&
+                ln[parser.next_nonspace] == cb.fence_char
+            Base.match(reClosingCodeFence, SubString(ln, parser.next_nonspace))
+        else
+            nothing
+        end
         if m !== nothing && length(m.match) >= cb.fence_length
             # closing fence - we're at end of line, so we can return
             finalize(parser, container, parser.line_number)
@@ -80,7 +80,7 @@ function Node(::Type{CodeBlock}, code::AbstractString; info::AbstractString = ""
     cb.is_fenced = true
     node = Node(cb)
     node.literal = code
-    node
+    return node
 end
 
 function fenced_code_block(parser::Parser, container::Node)

--- a/src/parsers/blocks/headings.jl
+++ b/src/parsers/blocks/headings.jl
@@ -19,7 +19,7 @@ can_contain(::Heading, t) = false
 function Node(::Type{Heading}, level::Int, children...)
     h = Heading()
     h.level = level
-    _build(h, children)
+    return _build(h, children)
 end
 
 function atx_heading(parser::Parser, container::Node)
@@ -73,7 +73,7 @@ function setext_heading(parser::Parser, container::Node)
                 if pos == 0
                     break
                 end
-                container.literal = container.literal[pos+1:end]
+                container.literal = container.literal[(pos + 1):end]
             end
             if !isempty(container.literal)
                 heading = Node(Heading(), container.sourcepos)

--- a/src/parsers/blocks/htmlblocks.jl
+++ b/src/parsers/blocks/htmlblocks.jl
@@ -8,7 +8,7 @@ end
 accepts_lines(::HtmlBlock) = true
 
 function continue_(::HtmlBlock, parser::Parser, container::Node)
-    (parser.blank && container.t.html_block_type in 6:7) ? 1 : 0
+    return (parser.blank && container.t.html_block_type in 6:7) ? 1 : 0
 end
 
 function finalize(::HtmlBlock, parser::Parser, block::Node)
@@ -22,7 +22,7 @@ can_contain(::HtmlBlock, t) = false
 function Node(::Type{HtmlBlock}, html::AbstractString)
     node = Node(HtmlBlock())
     node.literal = html
-    node
+    return node
 end
 
 function html_block(parser::Parser, container::Node)

--- a/src/parsers/blocks/lists.jl
+++ b/src/parsers/blocks/lists.jl
@@ -10,7 +10,7 @@ mutable struct ListData
 end
 
 function Base.:(==)(a::ListData, b::ListData)
-    a.type == b.type &&
+    return a.type == b.type &&
         a.tight == b.tight &&
         a.bullet_char == b.bullet_char &&
         a.start == b.start &&
@@ -66,7 +66,7 @@ function parse_list_marker(parser::Parser, container::Node)
 
     # If it interrupts paragraph make sure first line isn't blank.
     if container.t isa Paragraph &&
-       !occursin(reNonSpace, SubString(parser.buf, parser.next_nonspace + length(m.match)))
+            !occursin(reNonSpace, SubString(parser.buf, parser.next_nonspace + length(m.match)))
         return nothing
     end
 
@@ -101,8 +101,8 @@ end
 
 function lists_match(list_data::ListData, item_data::ListData)
     return list_data.type == item_data.type &&
-           list_data.delimiter == item_data.delimiter &&
-           list_data.bullet_char == item_data.bullet_char
+        list_data.delimiter == item_data.delimiter &&
+        list_data.bullet_char == item_data.bullet_char
 end
 
 accepts_lines(::List) = false
@@ -135,12 +135,12 @@ end
 can_contain(::List, t) = t isa Item
 
 function Node(
-    ::Type{List},
-    items::Node...;
-    ordered::Bool = false,
-    start::Int = 1,
-    tight::Bool = true,
-)
+        ::Type{List},
+        items::Node...;
+        ordered::Bool = false,
+        start::Int = 1,
+        tight::Bool = true,
+    )
     ld = ListData()
     ld.type = ordered ? :ordered : :bullet
     ld.start = start
@@ -158,7 +158,7 @@ function Node(
         end
         child = child.nxt
     end
-    node
+    return node
 end
 
 accepts_lines(::Item) = false

--- a/src/parsers/blocks/paragraphs.jl
+++ b/src/parsers/blocks/paragraphs.jl
@@ -14,7 +14,7 @@ function finalize(::Paragraph, p::Parser, block::Node)
     while get(block.literal, 1, nothing) === '['
         pos = parse_reference(p.inline_parser, block.literal, p.refmap)
         pos == 0 && break
-        block.literal = block.literal[pos+1:end]
+        block.literal = block.literal[(pos + 1):end]
         has_reference_defs = true
     end
     if has_reference_defs && is_blank(block.literal)

--- a/src/parsers/inlines.jl
+++ b/src/parsers/inlines.jl
@@ -28,16 +28,16 @@ mutable struct Delimiter
     numdelims::Int
     origdelims::Int
     node::Node
-    previous::Union{Nothing,Delimiter}
-    next::Union{Nothing,Delimiter}
+    previous::Union{Nothing, Delimiter}
+    next::Union{Nothing, Delimiter}
     can_open::Bool
     can_close::Bool
 end
 
 mutable struct Bracket
     node::Node
-    previous::Union{Nothing,Bracket}
-    previousDelimiter::Union{Nothing,Delimiter}
+    previous::Union{Nothing, Bracket}
+    previousDelimiter::Union{Nothing, Delimiter}
     index::Int
     image::Bool
     active::Bool
@@ -50,19 +50,19 @@ mutable struct InlineParser <: AbstractParser
     pos::Int
     len::Int
     # extra
-    brackets::Union{Nothing,Bracket}
-    delimiters::Union{Nothing,Delimiter}
-    refmap::Dict{String,Any}
-    inline_parsers::Dict{Char,Vector{Function}}
+    brackets::Union{Nothing, Bracket}
+    delimiters::Union{Nothing, Delimiter}
+    refmap::Dict{String, Any}
+    inline_parsers::Dict{Char, Vector{Function}}
     modifiers::Vector{Function}
     # Delimiter-based inline registries
-    delim_nodes::Dict{Tuple{Char,Int},Type{<:AbstractInline}}
-    flanking_rules::Dict{Char,Symbol}
+    delim_nodes::Dict{Tuple{Char, Int}, Type{<:AbstractInline}}
+    flanking_rules::Dict{Char, Symbol}
     odd_match_chars::Set{Char}
     # Precomputed emphasis lookups (derived from delim_nodes)
     delim_chars::Set{Char}
-    delim_counts::Dict{Char,Vector{Int}}
-    delim_max::Dict{Char,Int}
+    delim_counts::Dict{Char, Vector{Int}}
+    delim_max::Dict{Char, Int}
     # Fast lookup for ASCII trigger characters (indexed by codepoint+1)
     # Non-ASCII triggers fall back to haskey on inline_parsers
     trigger_table::BitVector
@@ -77,12 +77,12 @@ mutable struct InlineParser <: AbstractParser
         parser.refmap = Dict()
         parser.inline_parsers = Dict()
         parser.modifiers = Function[]
-        parser.delim_nodes = Dict{Tuple{Char,Int},Type{<:AbstractInline}}()
-        parser.flanking_rules = Dict{Char,Symbol}()
+        parser.delim_nodes = Dict{Tuple{Char, Int}, Type{<:AbstractInline}}()
+        parser.flanking_rules = Dict{Char, Symbol}()
         parser.odd_match_chars = Set{Char}()
         parser.delim_chars = Set{Char}()
-        parser.delim_counts = Dict{Char,Vector{Int}}()
-        parser.delim_max = Dict{Char,Int}()
+        parser.delim_counts = Dict{Char, Vector{Int}}()
+        parser.delim_max = Dict{Char, Int}()
         parser.trigger_table = falses(128)
         return parser
     end
@@ -102,6 +102,7 @@ function rebuild_delim_lookups!(ip::InlineParser)
         sort!(counts, rev = true)
         ip.delim_max[char] = first(counts)
     end
+    return
 end
 
 include("inlines/code.jl")
@@ -153,6 +154,7 @@ function parse_inlines(parser::InlineParser, block::Node)
     for fn in parser.modifiers
         fn(parser, block)
     end
+    return
 end
 
 parse(parser::InlineParser, block::Node) = parse_inlines(parser, block)

--- a/src/parsers/inlines/code.jl
+++ b/src/parsers/inlines/code.jl
@@ -4,7 +4,7 @@ struct Code <: AbstractInline end
 function Node(::Type{Code}, s::AbstractString)
     node = Node(Code())
     node.literal = s
-    node
+    return node
 end
 
 function parse_backticks(parser::InlineParser, block::Node)

--- a/src/parsers/inlines/emphasis.jl
+++ b/src/parsers/inlines/emphasis.jl
@@ -67,7 +67,7 @@ function scan_delims(parser::InlineParser, c::AbstractChar)
 
     can_open, can_close = if flanking == :underscore
         (left_flanking && (!right_flanking || punct_before)),
-        (right_flanking && (!left_flanking || punct_after))
+            (right_flanking && (!left_flanking || punct_after))
     elseif flanking == :permissive
         !ws_after, !ws_before
     elseif c in (''', '"')
@@ -131,7 +131,7 @@ end
 
 function process_emphasis(parser::InlineParser, stack_bottom)
     # Build openers_bottom keyed by (char, count) for proper multi-count handling
-    openers_bottom = Dict{Tuple{Char,Int},Union{Nothing,Delimiter}}()
+    openers_bottom = Dict{Tuple{Char, Int}, Union{Nothing, Delimiter}}()
 
     # Smart quotes use count 0 (not registered in delim_nodes)
     openers_bottom[(''', 0)] = stack_bottom
@@ -177,10 +177,10 @@ function process_emphasis(parser::InlineParser, stack_bottom)
             bottom_key =
                 closercc in (''', '"') ? (closercc, 0) : (closercc, closer.numdelims)
             while (
-                opener !== nothing &&
-                opener !== stack_bottom &&
-                opener !== get(openers_bottom, bottom_key, nothing)
-            )
+                    opener !== nothing &&
+                        opener !== stack_bottom &&
+                        opener !== get(openers_bottom, bottom_key, nothing)
+                )
                 # Apply odd_match rule only if char is in odd_match_chars
                 apply_odd_match = closercc in parser.odd_match_chars
                 odd_match =
@@ -197,9 +197,9 @@ function process_emphasis(parser::InlineParser, stack_bottom)
                 end
 
                 if opener.cc == closercc &&
-                   opener.can_open &&
-                   !odd_match &&
-                   count_compatible
+                        opener.can_open &&
+                        !odd_match &&
+                        count_compatible
                     opener_found = true
                     break
                 end
@@ -235,9 +235,9 @@ function process_emphasis(parser::InlineParser, stack_bottom)
                     opener.numdelims -= use_delims
                     closer.numdelims -= use_delims
                     opener_inl.literal =
-                        opener_inl.literal[1:length(opener_inl.literal)-use_delims]
+                        opener_inl.literal[1:(length(opener_inl.literal) - use_delims)]
                     closer_inl.literal =
-                        closer_inl.literal[1:length(closer_inl.literal)-use_delims]
+                        closer_inl.literal[1:(length(closer_inl.literal) - use_delims)]
 
                     # Build container node
                     container = Node(NodeType())::Node
@@ -291,6 +291,7 @@ function process_emphasis(parser::InlineParser, stack_bottom)
     while parser.delimiters !== nothing && parser.delimiters !== stack_bottom
         remove_delimiter(parser, parser.delimiters)
     end
+    return
 end
 process_emphasis(parser::InlineParser, ::Node) = process_emphasis(parser, nothing)
 

--- a/src/parsers/inlines/html.jl
+++ b/src/parsers/inlines/html.jl
@@ -7,7 +7,7 @@ end
 function Node(::Type{HtmlInline}, html::AbstractString)
     node = Node(HtmlInline())
     node.literal = html
-    node
+    return node
 end
 
 function parse_html_tag(parser::InlineParser, block::Node)

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -11,7 +11,7 @@ function Node(::Type{Link}, children...; dest::AbstractString, title::AbstractSt
     l = Link()
     l.destination = dest
     l.title = title
-    _build(l, children)
+    return _build(l, children)
 end
 
 """Image. Build with `Node(Image; dest="url", alt="text", title="optional")`."""
@@ -24,17 +24,17 @@ end
 is_container(::Image) = true
 
 function Node(
-    ::Type{Image};
-    dest::AbstractString,
-    alt::AbstractString = "",
-    title::AbstractString = "",
-)
+        ::Type{Image};
+        dest::AbstractString,
+        alt::AbstractString = "",
+        title::AbstractString = "",
+    )
     img = Image()
     img.destination = dest
     img.title = title
     node = Node(img)
     node.literal = alt
-    node
+    return node
 end
 
 chomp_ws(parser::InlineParser) = (consume(parser, match(reSpnl, parser)); true)
@@ -232,7 +232,7 @@ function add_bracket!(p::InlineParser, node::Node, index::Integer, img::Bool)
     if p.brackets !== nothing
         p.brackets.bracket_after = true
     end
-    p.brackets = Bracket(node, p.brackets, p.delimiters, index, img, true, false)
+    return p.brackets = Bracket(node, p.brackets, p.delimiters, index, img, true, false)
 end
 
 remove_bracket!(p::InlineParser) = p.brackets = p.brackets.previous

--- a/src/parsers/inlines/text.jl
+++ b/src/parsers/inlines/text.jl
@@ -13,7 +13,7 @@ function parse_string(parser::InlineParser, block::Node)
         char = trypeek(parser, Char, '\0')
         # Fast path for ASCII triggers, fallback to dict for non-ASCII
         is_trigger = if char <= '\x7f'
-            @inbounds parser.trigger_table[Int(char)+1]
+            @inbounds parser.trigger_table[Int(char) + 1]
         else
             haskey(parser.inline_parsers, char)
         end

--- a/src/parsers/rules.jl
+++ b/src/parsers/rules.jl
@@ -38,13 +38,13 @@ function enable!(p::AbstractParser, fn, rule::Rule)
         end
         # Update ASCII trigger lookup table for inline rules
         if fn === inline_rule && trigger <= '\x7f'
-            p.inline_parser.trigger_table[Int(trigger)+1] = true
+            p.inline_parser.trigger_table[Int(trigger) + 1] = true
         end
     end
     return p
 end
 enable!(p::AbstractParser, fn, ::Nothing) = p
-enable!(p::AbstractParser, fn, rules::Union{Tuple,Vector}) =
+enable!(p::AbstractParser, fn, rules::Union{Tuple, Vector}) =
     (foreach(r -> enable!(p, fn, r), rules); p)
 enable!(p::AbstractParser, fn, rule) = enable!(p, fn, fn(rule))
 
@@ -96,7 +96,7 @@ function enable!(p::AbstractParser, rule)
     return p
 end
 
-enable!(p::AbstractParser, rules::Union{Tuple,Vector}) =
+enable!(p::AbstractParser, rules::Union{Tuple, Vector}) =
     (foreach(r -> enable!(p, r), rules); p)
 
 get_funcs(p, ::typeof(block_rule), c) = get!(() -> Function[], p.block_starts, c)
@@ -127,7 +127,7 @@ disable!(p, [HtmlBlockRule(), HtmlInlineRule()])  # Disable raw HTML
 
 See also: [`enable!`](@ref), [`Parser`](@ref)
 """
-function disable!(p::AbstractParser, rules::Union{Tuple,Vector})
+function disable!(p::AbstractParser, rules::Union{Tuple, Vector})
     rules_kept = filter(!ruleoccursin(rules), p.rules)
     empty!(p.priorities)
     empty!(p.block_starts)

--- a/src/readers/json.jl
+++ b/src/readers/json.jl
@@ -48,7 +48,7 @@ function from_json_meta(val::AbstractDict)
     elseif t == "MetaList"
         return Any[from_json_meta(x) for x in c]
     elseif t == "MetaMap"
-        return Dict{String,Any}(string(k) => from_json_meta(v) for (k, v) in c)
+        return Dict{String, Any}(string(k) => from_json_meta(v) for (k, v) in c)
     elseif t == "MetaBool"
         return c
     else
@@ -71,6 +71,7 @@ function apply_attrs!(node::Node, attrs)
     for kv in kvs
         length(kv) >= 2 && setmeta!(node, kv[1], kv[2])
     end
+    return
 end
 
 # Inline text accumulation - join Str/Space/SoftBreak into Text nodes.
@@ -82,7 +83,7 @@ end
 
 function flush_text!(ctx::InlineContext, parent::Node)
     s = String(take!(ctx.buffer))
-    if !isempty(s)
+    return if !isempty(s)
         node = Node(Text())
         node.literal = s
         append_child(parent, node)
@@ -105,7 +106,7 @@ function process_inlines!(parent::Node, inlines::AbstractVector)
             !isnothing(child) && append_child(parent, child)
         end
     end
-    flush_text!(ctx, parent)
+    return flush_text!(ctx, parent)
 end
 
 # Block converters.
@@ -287,15 +288,17 @@ function table_from_json(content::AbstractVector)
     for cs in colspecs
         align_info = cs[1]
         align_t = get(align_info, "t", "AlignDefault")
-        push!(spec, if align_t == "AlignLeft"
-            :left
-        elseif align_t == "AlignRight"
-            :right
-        elseif align_t == "AlignCenter"
-            :center
-        else
-            :left
-        end)
+        push!(
+            spec, if align_t == "AlignLeft"
+                :left
+            elseif align_t == "AlignRight"
+                :right
+            elseif align_t == "AlignCenter"
+                :center
+            else
+                :left
+            end
+        )
     end
 
     table = Node(Table(spec))
@@ -348,10 +351,10 @@ function table_from_json(content::AbstractVector)
 end
 
 function table_row_from_json(
-    row_data::AbstractVector,
-    spec::Vector{Symbol},
-    is_header::Bool,
-)
+        row_data::AbstractVector,
+        spec::Vector{Symbol},
+        is_header::Bool,
+    )
     # Row: [attrs, cells]
     length(row_data) >= 2 || return nothing
     attrs, cells = row_data

--- a/src/utils/entitytrans.jl
+++ b/src/utils/entitytrans.jl
@@ -20,9 +20,9 @@ function HTMLunescape(s)
     @assert startswith(s, '&')
     if startswith(s, "&#")
         num = if startswith(s, "&#X") || startswith(s, "&#x")
-            Base.parse(UInt32, s[4:end-1]; base = 16)
+            Base.parse(UInt32, s[4:(end - 1)]; base = 16)
         else
-            Base.parse(UInt32, s[3:end-1])
+            Base.parse(UInt32, s[3:(end - 1)])
         end
         return (num == 0 || !isvalid(Char, num)) ? "\uFFFD" : string(Char(num))
     else

--- a/src/vendor/Crayons/src/crayon.jl
+++ b/src/vendor/Crayons/src/crayon.jl
@@ -48,7 +48,7 @@ end
 
 ANSIColor(r, g, b, style::ColorMode = COLORS_16, active = true) =
     ANSIColor(UInt8(r), UInt8(g), UInt8(b), style, active)
-ANSIColor() = ANSIColor(0x0, 0x0, 0x0, COLORS_16, false)
+ANSIColor() = ANSIColor(0x00, 0x00, 0x00, COLORS_16, false)
 ANSIColor(val::Integer, style::ColorMode, active::Bool = true) =
     ANSIColor(UInt8(val), 0, 0, style, active)
 
@@ -60,7 +60,7 @@ val(x::ANSIColor) = x.r
 # The inverse sets the color to default.
 # No point making active if color already is default
 Base.inv(x::ANSIColor) =
-    ANSIColor(0x9, 0x0, 0x0, COLORS_16, x.active && !(x.style == COLORS_16 && x.r == 9))
+    ANSIColor(0x09, 0x00, 0x00, COLORS_16, x.active && !(x.style == COLORS_16 && x.r == 9))
 
 struct ANSIStyle
     on::Bool
@@ -91,16 +91,16 @@ end
 
 anyactive(x::Crayon) = (
     (x.reset.active && x.reset.on) ||
-    x.fg.active ||
-    x.bg.active ||
-    x.bold.active ||
-    x.faint.active ||
-    x.italics.active ||
-    x.underline.active ||
-    x.blink.active ||
-    x.negative.active ||
-    x.conceal.active ||
-    x.strikethrough.active
+        x.fg.active ||
+        x.bg.active ||
+        x.bold.active ||
+        x.faint.active ||
+        x.italics.active ||
+        x.underline.active ||
+        x.blink.active ||
+        x.negative.active ||
+        x.conceal.active ||
+        x.strikethrough.active
 )
 
 Base.inv(c::Crayon) = Crayon(
@@ -125,7 +125,7 @@ function _have_color()
     end
 end
 function Base.print(io::IO, x::Crayon)
-    if anyactive(x) && (_have_color() || _force_color())
+    return if anyactive(x) && (_have_color() || _force_color())
         print(io, CSI)
         if (x.fg.style == COLORS_24BIT || x.bg.style == COLORS_24BIT)
             if _force_256_colors()
@@ -140,7 +140,7 @@ function Base.print(io::IO, x::Crayon)
 end
 
 function Base.show(io::IO, x::Crayon)
-    if anyactive(x)
+    return if anyactive(x)
         print(io, x)
         print(io, ESCAPED_CSI)
         _print(io, x)
@@ -150,11 +150,11 @@ end
 
 _ishex(c::Char) = isdigit(c) || ('a' <= c <= 'f') || ('A' <= c <= 'F')
 
-function _torgb(hex::UInt32)::NTuple{3,UInt8}
-    (hex << 8 >> 24, hex << 16 >> 24, hex << 24 >> 24)
+function _torgb(hex::UInt32)::NTuple{3, UInt8}
+    return (hex << 8 >> 24, hex << 16 >> 24, hex << 24 >> 24)
 end
 
-function _parse_color(c::Union{Integer,Symbol,NTuple{3,Integer},UInt32,Nothing})
+function _parse_color(c::Union{Integer, Symbol, NTuple{3, Integer}, UInt32, Nothing})
     ansicol = ANSIColor()
     if c !== nothing
         if isa(c, Symbol)
@@ -164,7 +164,7 @@ function _parse_color(c::Union{Integer,Symbol,NTuple{3,Integer},UInt32,Nothing})
             ansicol = ANSIColor(r, g, b, COLORS_24BIT)
         elseif isa(c, Integer)
             ansicol = ANSIColor(c, COLORS_256)
-        elseif isa(c, NTuple{3,Integer})
+        elseif isa(c, NTuple{3, Integer})
             ansicol = ANSIColor(c[1], c[2], c[3], COLORS_24BIT)
         else
             error("should not happen")
@@ -174,18 +174,18 @@ function _parse_color(c::Union{Integer,Symbol,NTuple{3,Integer},UInt32,Nothing})
 end
 
 function Crayon(;
-    foreground::Union{Int,Symbol,NTuple{3,Integer},UInt32,Nothing} = nothing,
-    background::Union{Int,Symbol,NTuple{3,Integer},UInt32,Nothing} = nothing,
-    reset::Union{Bool,Nothing} = nothing,
-    bold::Union{Bool,Nothing} = nothing,
-    faint::Union{Bool,Nothing} = nothing,
-    italics::Union{Bool,Nothing} = nothing,
-    underline::Union{Bool,Nothing} = nothing,
-    blink::Union{Bool,Nothing} = nothing,
-    negative::Union{Bool,Nothing} = nothing,
-    conceal::Union{Bool,Nothing} = nothing,
-    strikethrough::Union{Bool,Nothing} = nothing,
-)
+        foreground::Union{Int, Symbol, NTuple{3, Integer}, UInt32, Nothing} = nothing,
+        background::Union{Int, Symbol, NTuple{3, Integer}, UInt32, Nothing} = nothing,
+        reset::Union{Bool, Nothing} = nothing,
+        bold::Union{Bool, Nothing} = nothing,
+        faint::Union{Bool, Nothing} = nothing,
+        italics::Union{Bool, Nothing} = nothing,
+        underline::Union{Bool, Nothing} = nothing,
+        blink::Union{Bool, Nothing} = nothing,
+        negative::Union{Bool, Nothing} = nothing,
+        conceal::Union{Bool, Nothing} = nothing,
+        strikethrough::Union{Bool, Nothing} = nothing,
+    )
 
     fgcol = _parse_color(foreground)
     bgcol = _parse_color(background)
@@ -246,15 +246,15 @@ function _print(io::IO, c::Crayon)
     end
 
     for (style, val) in (
-        (c.bold, 1),
-        (c.faint, 2),
-        (c.italics, 3),
-        (c.underline, 4),
-        (c.blink, 5),
-        (c.negative, 7),
-        (c.conceal, 8),
-        (c.strikethrough, 9),
-    )
+            (c.bold, 1),
+            (c.faint, 2),
+            (c.italics, 3),
+            (c.underline, 4),
+            (c.blink, 5),
+            (c.negative, 7),
+            (c.conceal, 8),
+            (c.strikethrough, 9),
+        )
 
         if style.active
             !first_active && print(io, ";")

--- a/src/vendor/Crayons/src/crayon_stack.jl
+++ b/src/vendor/Crayons/src/crayon_stack.jl
@@ -7,12 +7,12 @@ end
 Base.print(io::IO, cs::CrayonStack) = print(io, cs.crayons[end])
 
 function CrayonStack(; incremental::Bool = false)
-    CrayonStack(
+    return CrayonStack(
         incremental,
         [
             Crayon(
-                ANSIColor(0x9, COLORS_16, !incremental),
-                ANSIColor(0x9, COLORS_16, !incremental),
+                ANSIColor(0x09, COLORS_16, !incremental),
+                ANSIColor(0x09, COLORS_16, !incremental),
                 ANSIStyle(false, !incremental),
                 ANSIStyle(false, !incremental),
                 ANSIStyle(false, !incremental),
@@ -87,8 +87,8 @@ function Base.pop!(cs::CrayonStack)
     pc = cs.crayons[end]
     if length(cs.crayons) == 1
         pc = Crayon(
-            ANSIColor(0x9, COLORS_16, true),
-            ANSIColor(0x9, COLORS_16, true),
+            ANSIColor(0x09, COLORS_16, true),
+            ANSIColor(0x09, COLORS_16, true),
             ANSIStyle(false, true),
             ANSIStyle(false, true),
             ANSIStyle(false, true),

--- a/src/vendor/Crayons/src/crayon_wrapper.jl
+++ b/src/vendor/Crayons/src/crayon_wrapper.jl
@@ -1,13 +1,13 @@
 struct CrayonWrapper
     c::Crayon
-    v::Vector{Union{CrayonWrapper,String}}
+    v::Vector{Union{CrayonWrapper, String}}
 end
 
-function (c::Crayon)(args::Union{CrayonWrapper,AbstractString}...)
+function (c::Crayon)(args::Union{CrayonWrapper, AbstractString}...)
     typefix(cw::CrayonWrapper) = cw
     typefix(str) = String(str)
 
-    CrayonWrapper(c, typefix.(collect(args)))
+    return CrayonWrapper(c, typefix.(collect(args)))
 end
 
 Base.show(io::IO, cw::CrayonWrapper) = _show(io, cw, CrayonStack(incremental = true))

--- a/src/vendor/Crayons/src/downcasts.jl
+++ b/src/vendor/Crayons/src/downcasts.jl
@@ -23,7 +23,7 @@ function to_256_colors(color::ANSIColor)
     r, g, b = rgb = color.r, color.g, color.b
     ansi = if r == g == b && r % 10 == 8
         232 + min((r - 8) ÷ 10, 23)  # gray level
-    elseif all(map(c -> (c & 0x1) == 0 && (c > 0 ? c == 128 || c == 192 : true), rgb))
+    elseif all(map(c -> (c & 0x01) == 0 && (c > 0 ? c == 128 || c == 192 : true), rgb))
         (r >> 7) + 2(g >> 7) + 4(b >> 7)  # primary color
     else
         r6, g6, b6 = map(c -> c < 48 ? 0 : (c < 114 ? 1 : trunc(Int, (c - 35) / 40)), rgb)

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -1,23 +1,23 @@
 function writer(
-    mime,
-    file::AbstractString,
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-    kws...,
-)
+        mime,
+        file::AbstractString,
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+        kws...,
+    )
     env = merge(env, Dict("outputfile" => file))
-    open(io -> writer(io, mime, ast, env; transform = transform, kws...), file, "w")
+    return open(io -> writer(io, mime, ast, env; transform = transform, kws...), file, "w")
 end
 function writer(
-    mime,
-    io::IO,
-    ast::Node,
-    env = nothing;
-    transform = default_transform,
-    kws...,
-)
-    writer(io, mime, ast, env; transform = transform, kws...)
+        mime,
+        io::IO,
+        ast::Node,
+        env = nothing;
+        transform = default_transform,
+        kws...,
+    )
+    return writer(io, mime, ast, env; transform = transform, kws...)
 end
 function writer(mime, ast::Node, env = nothing; transform = default_transform, kws...)
     io = IOBuffer()
@@ -26,34 +26,34 @@ function writer(mime, ast::Node, env = nothing; transform = default_transform, k
 end
 
 function writer(
-    io::IO,
-    mime::MIME,
-    ast::Node,
-    env::Dict;
-    transform = default_transform,
-    kws...,
-)
+        io::IO,
+        mime::MIME,
+        ast::Node,
+        env::Dict;
+        transform = default_transform,
+        kws...,
+    )
     # Merge all metadata provided, priority is right-to-left.
     env = recursive_merge(
         default_config(),
         env,
         frontmatter(ast),
-        something(ast.meta, Dict{String,Any}()),
+        something(ast.meta, Dict{String, Any}()),
     )
-    show(io, mime, ast, env; transform = transform, kws...)
+    return show(io, mime, ast, env; transform = transform, kws...)
 end
 function writer(
-    io::IO,
-    mime::MIME,
-    ast::Node,
-    ::Nothing;
-    transform = default_transform,
-    kws...,
-)
-    show(io, mime, ast; transform = transform, kws...)
+        io::IO,
+        mime::MIME,
+        ast::Node,
+        ::Nothing;
+        transform = default_transform,
+        kws...,
+    )
+    return show(io, mime, ast; transform = transform, kws...)
 end
 
-default_config() = Dict{String,Any}(
+default_config() = Dict{String, Any}(
     "authors" => [],
     "curdir" => pwd(),
     "title" => "",
@@ -61,7 +61,7 @@ default_config() = Dict{String,Any}(
     "abstract" => "",
     "keywords" => [],
     "lang" => "en",
-    "latex" => Dict{String,Any}("documentclass" => "article"),
+    "latex" => Dict{String, Any}("documentclass" => "article"),
 )
 
 recursive_merge(ds::AbstractDict...) = merge(recursive_merge, ds...)
@@ -91,24 +91,24 @@ author: Jane Doe
 frontmatter(ast)  # Dict("title" => "My Document", "author" => "Jane Doe")
 ```
 """
-frontmatter(n::Node) = has_frontmatter(n) ? n.first_child.t.data : Dict{String,Any}()
+frontmatter(n::Node) = has_frontmatter(n) ? n.first_child.t.data : Dict{String, Any}()
 has_frontmatter(n::Node) = !isnull(n.first_child) && n.first_child.t isa FrontMatter
 
-mutable struct Writer{F,I<:IO,T}
+mutable struct Writer{F, I <: IO, T}
     format::F
     buffer::I
     last::Char
     enabled::Bool
-    context::Dict{Symbol,Any}
-    env::Dict{String,Any}
+    context::Dict{Symbol, Any}
+    env::Dict{String, Any}
     transform::T
 end
 Writer(
     format,
     buffer = IOBuffer(),
-    env = Dict{String,Any}();
+    env = Dict{String, Any}();
     transform = default_transform,
-) = Writer(format, buffer, '\n', true, Dict{Symbol,Any}(), env, transform)
+) = Writer(format, buffer, '\n', true, Dict{Symbol, Any}(), env, transform)
 
 Base.get(w::Writer, k::Symbol, default) = get(w.context, k, default)
 Base.get!(f::Function, w::Writer, k::Symbol) = get!(f, w.context, k)
@@ -180,5 +180,6 @@ function ast_dump(io::IO, ast::Node)
             println(io, ' '^(indent + 4), repr(node.literal))
         end
     end
+    return
 end
 ast_dump(ast::Node) = ast_dump(stdout, ast)

--- a/src/writers/html.jl
+++ b/src/writers/html.jl
@@ -1,13 +1,13 @@
 # Public.
 
 function Base.show(
-    io::IO,
-    ::MIME"text/html",
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-    kws...,
-)
+        io::IO,
+        ::MIME"text/html",
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+        kws...,
+    )
     w = Writer(HTML(; kws...), io, env; transform = transform)
     write_html(w, ast)
     return nothing
@@ -47,7 +47,7 @@ mutable struct HTML
     disable_tags::Int
     softbreak::String
     safe::Bool
-    sourcepos::Union{Bool,Function}
+    sourcepos::Union{Bool, Function}
 
     function HTML(; softbreak = "\n", safe = false, sourcepos = false)
         format = new()
@@ -65,6 +65,7 @@ function write_html(writer::Writer, ast::Node)
         node, entering = _transform(writer.transform, mime, node, entering, writer)
         write_html(node.t, writer, node, entering)
     end
+    return
 end
 
 const reUnsafeProtocol = r"^javascript:|vbscript:|file:|data:"i
@@ -95,11 +96,11 @@ write_html(::SoftBreak, r, n, ent) = literal(r, r.format.softbreak)
 
 function write_html(::LineBreak, r, n, ent)
     tag(r, "br", attributes(r, n), true)
-    cr(r)
+    return cr(r)
 end
 
 function write_html(link::Link, r, n, ent)
-    if ent
+    return if ent
         attrs = []
         if !(r.format.safe && potentially_unsafe(link.destination))
             push!(attrs, "href" => escape_xml(link.destination))
@@ -114,7 +115,7 @@ function write_html(link::Link, r, n, ent)
 end
 
 function write_html(image::Image, r, n, ent)
-    if ent
+    return if ent
         if r.format.disable_tags == 0
             if r.format.safe && potentially_unsafe(image.destination)
                 literal(r, "<img src=\"\" alt=\"")
@@ -149,7 +150,7 @@ function write_html(::Paragraph, r, n, ent)
     if !isnull(grandparent) && grandparent.t isa DefinitionList && grandparent.t.tight
         return
     end
-    if ent
+    return if ent
         attrs = attributes(r, n)
         cr(r)
         tag(r, "p", attrs)
@@ -161,7 +162,7 @@ end
 
 function write_html(::Heading, r, n, ent)
     level = n.t.level
-    if ent
+    return if ent
         attrs = attributes(r, n)
         cr(r)
         tag(r, HEADING_OPEN[level], attrs)
@@ -182,7 +183,7 @@ end
 function write_html(::Code, r, n, ent)
     tag(r, "code", attributes(r, n))
     literal(r, escape_xml(n.literal))
-    tag(r, "/code")
+    return tag(r, "/code")
 end
 
 function write_html(::CodeBlock, r, n, ent)
@@ -197,18 +198,18 @@ function write_html(::CodeBlock, r, n, ent)
     literal(r, escape_xml(n.literal))
     tag(r, "/code")
     tag(r, "/pre")
-    cr(r)
+    return cr(r)
 end
 
 function write_html(::ThematicBreak, r, n, ent)
     attrs = attributes(r, n)
     cr(r)
     tag(r, "hr", attrs, true)
-    cr(r)
+    return cr(r)
 end
 
 function write_html(::BlockQuote, r, n, ent)
-    if ent
+    return if ent
         attrs = attributes(r, n)
         cr(r)
         tag(r, "blockquote", attrs)
@@ -222,7 +223,7 @@ end
 
 function write_html(::List, r, n, ent)
     tagname = n.t.list_data.type === :bullet ? "ul" : "ol"
-    if ent
+    return if ent
         attrs = attributes(r, n)
         start = n.t.list_data.start
         if start !== nothing && start != 1
@@ -239,7 +240,7 @@ function write_html(::List, r, n, ent)
 end
 
 function write_html(::Item, r, n, ent)
-    if ent
+    return if ent
         attrs = attributes(r, n)
         tag(r, "li", attrs)
     else
@@ -254,13 +255,13 @@ write_html(::HtmlInline, r, n, ent) =
 function write_html(::HtmlBlock, r, n, ent)
     cr(r)
     literal(r, r.format.safe ? "<!-- raw HTML omitted -->" : n.literal)
-    cr(r)
+    return cr(r)
 end
 
 function attributes(r, n, out = [])
     # Maintain the order of the attributes, but merge duplicates.
     order = String[]
-    dict = Dict{String,Any}()
+    dict = Dict{String, Any}()
     if _has_sourcepos(r.format.sourcepos)
         if n.sourcepos !== nothing
             p = n.sourcepos

--- a/src/writers/json.jl
+++ b/src/writers/json.jl
@@ -32,18 +32,18 @@ d = json(Dict, ast)
 json(args...; dicttype = Dict) =
     writer(MIME"application/pandoc+json"(), args...; dicttype = dicttype)
 
-function json(::Type{D}, ast::Node) where {D<:AbstractDict}
+function json(::Type{D}, ast::Node) where {D <: AbstractDict}
     return build_json_dict(D, ast)
 end
 
 function Base.show(
-    io::IO,
-    ::MIME"application/pandoc+json",
-    ast::Node,
-    env = Dict{String,Any}();
-    dicttype = Dict,
-    kws...,
-)
+        io::IO,
+        ::MIME"application/pandoc+json",
+        ast::Node,
+        env = Dict{String, Any}();
+        dicttype = Dict,
+        kws...,
+    )
     DictType = get(env, "dicttype", dicttype)
     doc = build_json_dict(DictType, ast)
     _json(io, doc)
@@ -69,18 +69,18 @@ end
 mime_to_str(::MIME"application/pandoc+json") = "json"
 
 # Context for building AST during traversal.
-mutable struct JSONContext{D<:AbstractDict}
+mutable struct JSONContext{D <: AbstractDict}
     doc::D
     stack::Vector{Vector{Any}}  # Stack of inline/block containers
 end
 
 function JSONContext(DictType::Type = Dict)
-    doc = DictType{String,Any}(
+    doc = DictType{String, Any}(
         "pandoc-api-version" => [1, 23, 1],
-        "meta" => DictType{String,Any}(),
+        "meta" => DictType{String, Any}(),
         "blocks" => Any[],
     )
-    JSONContext{typeof(doc)}(doc, Vector{Any}[doc["blocks"]])
+    return JSONContext{typeof(doc)}(doc, Vector{Any}[doc["blocks"]])
 end
 
 # Current container being built.
@@ -114,7 +114,7 @@ function node_attr(node::Node)
     else
         String.(split(class_val))
     end
-    Any[id, classes, Any[]]
+    return Any[id, classes, Any[]]
 end
 
 # Convert frontmatter values to meta format.
@@ -155,7 +155,7 @@ function text_to_inlines(ctx::JSONContext, s::AbstractString)
             i = j
         end
     end
-    result
+    return result
 end
 
 # Core block types.
@@ -163,7 +163,7 @@ end
 write_json(::Document, ctx, node, enter) = nothing
 
 function write_json(::Paragraph, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -171,19 +171,19 @@ function write_json(::Paragraph, ctx, node, enter)
         # Use Plain for tight list items, Para otherwise.
         grandparent = node.parent.parent
         block_type =
-            if !isnull(grandparent) &&
-               grandparent.t isa List &&
-               grandparent.t.list_data.tight
-                "Plain"
-            else
-                "Para"
-            end
+        if !isnull(grandparent) &&
+                grandparent.t isa List &&
+                grandparent.t.list_data.tight
+            "Plain"
+        else
+            "Para"
+        end
         push_element!(ctx, json_el(ctx, block_type, inlines))
     end
 end
 
 function write_json(h::Heading, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -199,11 +199,11 @@ function write_json(::CodeBlock, ctx, node, enter)
     attr = Any["", classes, Any[]]
     # Strip trailing newline.
     content = chomp(node.literal)
-    push_element!(ctx, json_el(ctx, "CodeBlock", Any[attr, content]))
+    return push_element!(ctx, json_el(ctx, "CodeBlock", Any[attr, content]))
 end
 
 function write_json(::BlockQuote, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else
@@ -214,18 +214,18 @@ end
 
 function write_json(::ThematicBreak, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "HorizontalRule"))
+    return push_element!(ctx, json_el(ctx, "HorizontalRule"))
 end
 
 function write_json(::HtmlBlock, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawBlock", Any["html", node.literal]))
+    return push_element!(ctx, json_el(ctx, "RawBlock", Any["html", node.literal]))
 end
 
 # Lists.
 
 function write_json(list::List, ctx, node, enter)
-    if enter
+    return if enter
         items = Any[]
         push_container!(ctx, items)
     else
@@ -247,7 +247,7 @@ function write_json(list::List, ctx, node, enter)
 end
 
 function write_json(::Item, ctx, node, enter)
-    if enter
+    return if enter
         blocks = Any[]
         push_container!(ctx, blocks)
     else
@@ -260,7 +260,7 @@ end
 
 function write_json(::Text, ctx, node, enter)
     enter || return
-    append!(current(ctx), text_to_inlines(ctx, node.literal))
+    return append!(current(ctx), text_to_inlines(ctx, node.literal))
 end
 
 write_json(::SoftBreak, ctx, node, enter) =
@@ -271,11 +271,11 @@ write_json(::LineBreak, ctx, node, enter) =
 
 function write_json(::Code, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "Code", Any[empty_attr(), node.literal]))
+    return push_element!(ctx, json_el(ctx, "Code", Any[empty_attr(), node.literal]))
 end
 
 function write_json(::Emph, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -285,7 +285,7 @@ function write_json(::Emph, ctx, node, enter)
 end
 
 function write_json(::Strong, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -295,7 +295,7 @@ function write_json(::Strong, ctx, node, enter)
 end
 
 function write_json(link::Link, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -306,7 +306,7 @@ function write_json(link::Link, ctx, node, enter)
 end
 
 function write_json(img::Image, ctx, node, enter)
-    if enter
+    return if enter
         inlines = Any[]
         push_container!(ctx, inlines)
     else
@@ -318,7 +318,7 @@ end
 
 function write_json(::HtmlInline, ctx, node, enter)
     enter || return
-    push_element!(ctx, json_el(ctx, "RawInline", Any["html", node.literal]))
+    return push_element!(ctx, json_el(ctx, "RawInline", Any["html", node.literal]))
 end
 
 write_json(::Backslash, ctx, node, enter) = nothing

--- a/src/writers/latex.jl
+++ b/src/writers/latex.jl
@@ -1,12 +1,12 @@
 # Public.
 
 function Base.show(
-    io::IO,
-    ::MIME"text/latex",
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-)
+        io::IO,
+        ::MIME"text/latex",
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+    )
     w = Writer(LaTeX(), io, env; transform = transform)
     write_latex(w, ast)
     return nothing
@@ -47,6 +47,7 @@ function write_latex(writer::Writer, ast::Node)
         end
         write_latex(node.t, writer, node, entering)
     end
+    return
 end
 
 write_latex(::Document, w, node, ent) = nothing
@@ -61,26 +62,26 @@ write_latex(::LineBreak, w, node, ent) = cr(w)
 function write_latex(::Code, w, node, ent)
     literal(w, "\\texttt{")
     latex_escape(w, node.literal)
-    literal(w, "}")
+    return literal(w, "}")
 end
 
 write_latex(::HtmlInline, w, node, ent) = nothing
 
 function write_latex(link::Link, w, node, ent)
-    if ent
+    return if ent
         # Link destinations that begin with a # are taken to be internal to the
         # document. LaTeX wants to use a hyperlink rather than an href for
         # these, so branch based on it to allow both types of links to be used.
         # Generating `\url` commands is not supported.
         type, n = startswith(link.destination, '#') ? ("hyperlink", 1) : ("href", 0)
-        literal(w, "\\$type{$(latex_escape(chop(link.destination; head=n, tail=0)))}{")
+        literal(w, "\\$type{$(latex_escape(chop(link.destination; head = n, tail = 0)))}{")
     else
         literal(w, "}")
     end
 end
 
 function write_latex(image::Image, w, node, ent)
-    if ent
+    return if ent
         cr(w)
         literal(w, "\\begin{figure}\n")
         literal(w, "\\centering\n")
@@ -103,11 +104,11 @@ write_latex(::Emph, w, node, ent) = literal(w, ent ? "\\textit{" : "}")
 write_latex(::Strong, w, node, ent) = literal(w, ent ? "\\textbf{" : "}")
 
 function write_latex(::Paragraph, w, node, ent)
-    literal(w, ent ? "" : "\\par\n")
+    return literal(w, ent ? "" : "\\par\n")
 end
 
 function write_latex(::Heading, w, node, ent)
-    if ent
+    return if ent
         cr(w)
         n = node.t.level
         name = n ≤ 3 ? "sub"^(n - 1) * "section" : "sub"^(n - 4) * "paragraph"
@@ -121,7 +122,7 @@ end
 function write_latex(::BlockQuote, w, node, ent)
     cr(w)
     literal(w, ent ? "\\begin{quote}" : "\\end{quote}")
-    cr(w)
+    return cr(w)
 end
 
 function write_latex(list::List, w, node, ent)
@@ -131,7 +132,7 @@ function write_latex(list::List, w, node, ent)
         literal(w, "\\begin{$command}\n")
         if command == "enumerate"
             literal(w, "\\def\\labelenumi{\\arabic{enumi}.}\n")
-            literal(w, "\\setcounter{enumi}{$(list.list_data.start-1)}\n")
+            literal(w, "\\setcounter{enumi}{$(list.list_data.start - 1)}\n")
         end
         if list.list_data.tight
             literal(w, "\\setlength{\\itemsep}{0pt}\n")
@@ -140,18 +141,18 @@ function write_latex(list::List, w, node, ent)
     else
         literal(w, "\\end{$command}")
     end
-    cr(w)
+    return cr(w)
 end
 
 function write_latex(::Item, w, node, ent)
     literal(w, ent ? "\\item" : "")
-    cr(w)
+    return cr(w)
 end
 
 function write_latex(::ThematicBreak, w, node, ent)
     cr(w)
     literal(w, "\\par\\bigskip\\noindent\\hrulefill\\par\\bigskip")
-    cr(w)
+    return cr(w)
 end
 
 function write_latex(c::CodeBlock, w, node, ent)
@@ -162,7 +163,7 @@ function write_latex(c::CodeBlock, w, node, ent)
     literal(w, node.literal)
     cr(w)
     literal(w, "\\end{$environment}")
-    cr(w)
+    return cr(w)
 end
 
 write_latex(::HtmlBlock, w, node, ent) = nothing
@@ -175,6 +176,7 @@ let chars = Dict('^' => "\\^{}", '\\' => "{\\textbackslash}", '~' => "{\\textasc
         for ch in s
             literal(w, get(chars, ch, ch))
         end
+        return
     end
 
     global function latex_escape(s::AbstractString)

--- a/src/writers/markdown.jl
+++ b/src/writers/markdown.jl
@@ -1,12 +1,12 @@
 # Public.
 
 function Base.show(
-    io::IO,
-    ::MIME"text/markdown",
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-)
+        io::IO,
+        ::MIME"text/markdown",
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+    )
     w = Writer(Markdown(io), io, env; transform = transform)
     write_markdown(w, ast)
     return nothing
@@ -35,7 +35,7 @@ markdown(args...; kws...) = writer(MIME"text/markdown"(), args...; kws...)
 
 mime_to_str(::MIME"text/markdown") = "markdown"
 
-mutable struct Markdown{I<:IO}
+mutable struct Markdown{I <: IO}
     buffer::I
     indent::Int
     margin::Vector{MarginSegment}
@@ -57,7 +57,7 @@ function print_margin_rstrip(w)
             end
         end
     end
-    literal(w, rstrip(margin))
+    return literal(w, rstrip(margin))
 end
 
 function write_markdown(writer::Writer, ast::Node)
@@ -66,6 +66,7 @@ function write_markdown(writer::Writer, ast::Node)
         node, entering = _transform(writer.transform, mime, node, entering, writer)
         write_markdown(node.t, writer, node, entering)
     end
+    return
 end
 
 function linebreak(w, node)
@@ -89,7 +90,7 @@ write_markdown(::Text, w, node, ent) = literal(w, node.literal)
 write_markdown(::Backslash, w, node, ent) = literal(w, "\\")
 
 function write_markdown(::SoftBreak, w, node, ent)
-    if node.parent.t isa Heading
+    return if node.parent.t isa Heading
         literal(w, " ")
     else
         cr(w)
@@ -103,7 +104,7 @@ function write_markdown(::LineBreak, w, node, ent)
         literal(w, "  ")
     end
     cr(w)
-    print_margin(w)
+    return print_margin(w)
 end
 
 function write_markdown(::Code, w, node, ent)
@@ -120,11 +121,11 @@ function write_markdown(::Code, w, node, ent)
     pad && literal(w, " ")
     literal(w, content)
     pad && literal(w, " ")
-    literal(w, "`"^backticks)
+    return literal(w, "`"^backticks)
 end
 
 function write_markdown(t::HtmlInline, w, node, ent)
-    if t.raw
+    return if t.raw
         num = foldl(eachmatch(r"`+", node.literal); init = 0) do a, b
             max(a, length(b.match))
         end
@@ -137,7 +138,7 @@ function write_markdown(t::HtmlInline, w, node, ent)
 end
 
 function write_markdown(link::Link, w, node, ent)
-    if ent
+    return if ent
         literal(w, "[")
     else
         literal(w, "](", link.destination)
@@ -147,7 +148,7 @@ function write_markdown(link::Link, w, node, ent)
 end
 
 function write_markdown(image::Image, w, node, ent)
-    if ent
+    return if ent
         literal(w, "![")
     else
         literal(w, "](", image.destination)
@@ -161,7 +162,7 @@ write_markdown(::Emph, w, node, ent) = literal(w, node.literal)
 write_markdown(::Strong, w, node, ent) = literal(w, node.literal)
 
 function write_markdown(::Paragraph, w, node, ent)
-    if ent
+    return if ent
         print_margin(w)
     else
         cr(w)
@@ -170,7 +171,7 @@ function write_markdown(::Paragraph, w, node, ent)
 end
 
 function write_markdown(heading::Heading, w, node, ent)
-    if ent
+    return if ent
         print_margin(w)
         literal(w, "#"^heading.level, " ")
     else
@@ -180,7 +181,7 @@ function write_markdown(heading::Heading, w, node, ent)
 end
 
 function write_markdown(::BlockQuote, w, node, ent)
-    if ent
+    return if ent
         push_margin!(w, ">")
         push_margin!(w, " ")
     else
@@ -193,7 +194,7 @@ function write_markdown(::BlockQuote, w, node, ent)
 end
 
 function write_markdown(list::List, w, node, ent)
-    if ent
+    return if ent
         w.format.list_depth += 1
         push!(w.format.list_item_number, list.list_data.start)
     else
@@ -205,7 +206,7 @@ function write_markdown(list::List, w, node, ent)
 end
 
 function write_markdown(item::Item, w, node, enter)
-    if enter
+    return if enter
         if item.list_data.type === :ordered
             number = lpad(string(w.format.list_item_number[end], ". "), 4, " ")
             w.format.list_item_number[end] += 1
@@ -232,7 +233,7 @@ function write_markdown(::ThematicBreak, w, node, ent)
     print_margin(w)
     literal(w, "* * *")
     cr(w)
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
 function write_markdown(code::CodeBlock, w, node, ent)
@@ -255,7 +256,7 @@ function write_markdown(code::CodeBlock, w, node, ent)
             literal(w, ' '^indent, line)
         end
     end
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
 function write_markdown(t::HtmlBlock, w, node, ent)
@@ -275,5 +276,5 @@ function write_markdown(t::HtmlBlock, w, node, ent)
         end
         cr(w)
     end
-    linebreak(w, node)
+    return linebreak(w, node)
 end

--- a/src/writers/notebook.jl
+++ b/src/writers/notebook.jl
@@ -1,12 +1,12 @@
 # Public.
 
 function Base.show(
-    io::IO,
-    ::MIME"application/x-ipynb+json",
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-)
+        io::IO,
+        ::MIME"application/x-ipynb+json",
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+    )
     json = Dict(
         "cells" => [],
         "metadata" => Dict(
@@ -57,10 +57,10 @@ mime_to_str(::MIME"application/x-ipynb+json") = "notebook"
 
 function write_notebook(json, node, enter, env)
     split_lines = str -> collect(eachline(IOBuffer(str); keep = true))
-    if !isnull(node) &&
-       node.t isa CodeBlock &&
-       node.parent.t isa Document &&
-       node.t.info == "julia"
+    return if !isnull(node) &&
+            node.t isa CodeBlock &&
+            node.parent.t isa Document &&
+            node.t.info == "julia"
         # Toplevel Julia codeblocks become code cells.
         cell = Dict(
             "cell_type" => "code",
@@ -88,14 +88,14 @@ function write_notebook(json, node, enter, env)
     end
 end
 
-struct StringContext{T<:IO} <: IO
+struct StringContext{T <: IO} <: IO
     io::T
 end
 
-Base.write(io::StringContext, byte::UInt8) = write(io.io, ESCAPED_ARRAY[byte+1])
+Base.write(io::StringContext, byte::UInt8) = write(io.io, ESCAPED_ARRAY[byte + 1])
 
 # JSON writer context with formatting options.
-struct JSONWriter{T<:IO}
+struct JSONWriter{T <: IO}
     io::T
     indent::Int
     sorted::Bool
@@ -111,7 +111,7 @@ _json(io::IO, x; indent::Int = 0, sorted::Bool = true) =
 function _json(w::JSONWriter, str::AbstractString)
     write(w.io, STRING_DELIM)
     print(StringContext(w.io), str)
-    write(w.io, STRING_DELIM)
+    return write(w.io, STRING_DELIM)
 end
 _json(w::JSONWriter, ::Nothing) = print(w.io, "null")
 _json(w::JSONWriter, num::Real) = print(w.io, num)
@@ -130,7 +130,7 @@ function _json(w::JSONWriter, dict::AbstractDict)
     if !isempty(ks) && w.indent > 0
         print(w.io, "\n", " "^(w.indent * w.depth))
     end
-    print(w.io, "}")
+    return print(w.io, "}")
 end
 
 function _json(w::JSONWriter, vec::AbstractVector)
@@ -144,7 +144,7 @@ function _json(w::JSONWriter, vec::AbstractVector)
     if !isempty(vec) && w.indent > 0
         print(w.io, "\n", " "^(w.indent * w.depth))
     end
-    print(w.io, "]")
+    return print(w.io, "]")
 end
 
 # The following bytes have significant meaning in JSON
@@ -199,8 +199,8 @@ const ESCAPES = Dict(
 
 const REVERSE_ESCAPES = Dict(reverse(p) for p in ESCAPES)
 const ESCAPED_ARRAY = Vector{Vector{UInt8}}(undef, 256)
-for c = 0x00:0xFF
-    ESCAPED_ARRAY[c+1] = if c == SOLIDUS
+for c in 0x00:0xFF
+    ESCAPED_ARRAY[c + 1] = if c == SOLIDUS
         [SOLIDUS]  # don't escape this one
     elseif c ≥ 0x80
         [c]  # UTF-8 character copied verbatim

--- a/src/writers/term.jl
+++ b/src/writers/term.jl
@@ -1,12 +1,12 @@
 # Public.
 
 function Base.show(
-    io::IO,
-    ::MIME"text/plain",
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-)
+        io::IO,
+        ::MIME"text/plain",
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+    )
     w = Writer(Term(), io, env; transform = transform)
     write_term(w, ast)
     # Writing is done to an intermediate buffer and then written to the
@@ -189,6 +189,7 @@ function write_term(writer::Writer, ast::Node)
         node, entering = _transform(writer.transform, mime, node, entering, writer)
         write_term(node.t, writer, node, entering)
     end
+    return
 end
 
 # Utilities.
@@ -238,11 +239,11 @@ Adds new segmant to the margin buffer. `count` determines how many time
 `initial` is printed. After that, the width of `rest` is printed instead.
 """
 function push_margin!(
-    r::Writer,
-    count::Integer,
-    initial::AbstractString,
-    rest::AbstractString,
-)
+        r::Writer,
+        count::Integer,
+        initial::AbstractString,
+        rest::AbstractString,
+    )
     width = Base.Unicode.textwidth(rest)
     r.format.indent += width
     seg = MarginSegment(initial, width, count)
@@ -303,6 +304,7 @@ function print_margin(r::Writer)
             seg.count > 0 && (seg.count -= 1)
         end
     end
+    return
 end
 
 function maybe_print_margin(r, node::Node)
@@ -324,7 +326,7 @@ function print_literal(r::Writer{Term}, parts...)
     # use printing them.
     available_columns(r) < 5 && return
 
-    if r.format.wrap < 0
+    return if r.format.wrap < 0
         # We just print everything normally here, allowing for the possibility
         # of bad automatic line wrapping by the terminal.
         for part in parts
@@ -355,7 +357,7 @@ end
 function print_literal_part(r::Writer{Term}, lit::AbstractString, rec = 0)
     width = Base.Unicode.textwidth(lit)
     space = (available_columns(r) - r.format.wrap) + ispunct(get(lit, 1, '\0'))
-    if width <= space
+    return if width <= space
         print(r.format.buffer, lit)
         r.format.wrap += width
     else
@@ -378,7 +380,7 @@ print_literal_part(r::Writer{Term}, c::Crayon) = print(r.format.buffer, c)
 # Rendering to terminal.
 
 function write_term(::Document, render, node, enter)
-    if enter
+    return if enter
         push_margin!(render, LEFT_MARGIN, crayon"")
     else
         pop_margin!(render)
@@ -395,19 +397,19 @@ function write_term(::Text, render, node, enter)
             text = to_superscript(text)
         end
     end
-    print_literal(render, text)
+    return print_literal(render, text)
 end
 
 write_term(::Backslash, w, node, ent) = nothing
 
 function write_term(::SoftBreak, render, node, enter)
-    print_literal(render, " ")
+    return print_literal(render, " ")
 end
 
 function write_term(::LineBreak, render, node, enter)
     print(render.format.buffer, "\n")
     print_margin(render)
-    render.format.wrap = render.format.wrap < 0 ? -1 : 0
+    return render.format.wrap = render.format.wrap < 0 ? -1 : 0
 end
 
 function write_term(::Code, render, node, enter)
@@ -416,7 +418,7 @@ function write_term(::Code, render, node, enter)
     push_inline!(render, style)
     print_literal(render, node.literal)
     pop_inline!(render)
-    print_literal(render, inv(style))
+    return print_literal(render, inv(style))
 end
 
 function write_term(::HtmlInline, render, node, enter)
@@ -425,12 +427,12 @@ function write_term(::HtmlInline, render, node, enter)
     push_inline!(render, style)
     print_literal(render, node.literal)
     pop_inline!(render)
-    print_literal(render, inv(style))
+    return print_literal(render, inv(style))
 end
 
 function write_term(::Link, render, node, enter)
     style = crayon"blue underline"
-    if enter
+    return if enter
         print_literal(render, style)
         push_inline!(render, style)
     else
@@ -441,7 +443,7 @@ end
 
 function write_term(::Image, render, node, enter)
     style = crayon"green"
-    if enter
+    return if enter
         print_literal(render, style)
         push_inline!(render, style)
     else
@@ -452,7 +454,7 @@ end
 
 function write_term(::Emph, render, node, enter)
     style = crayon"italics"
-    if enter
+    return if enter
         print_literal(render, style)
         push_inline!(render, style)
     else
@@ -463,7 +465,7 @@ end
 
 function write_term(::Strong, render, node, enter)
     style = crayon"bold"
-    if enter
+    return if enter
         print_literal(render, style)
         push_inline!(render, style)
     else
@@ -473,7 +475,7 @@ function write_term(::Strong, render, node, enter)
 end
 
 function write_term(::Paragraph, render, node, enter)
-    if enter
+    return if enter
         render.format.wrap = 0
         print_margin(render)
     else
@@ -487,7 +489,7 @@ function write_term(::Paragraph, render, node, enter)
 end
 
 function write_term(heading::Heading, render, node, enter)
-    if enter
+    return if enter
         print_margin(render)
         style = crayon"blue bold"
         print_literal(render, style, "#"^heading.level, inv(style), " ")
@@ -501,7 +503,7 @@ function write_term(heading::Heading, render, node, enter)
 end
 
 function write_term(::BlockQuote, render, node, enter)
-    if enter
+    return if enter
         push_margin!(render, "│", crayon"bold")
         push_margin!(render, " ", crayon"")
     else
@@ -516,7 +518,7 @@ function write_term(::BlockQuote, render, node, enter)
 end
 
 function write_term(list::List, render, node, enter)
-    if enter
+    return if enter
         render.format.list_depth += 1
         push!(render.format.list_item_number, list.list_data.start)
         push_margin!(render, " ", crayon"")
@@ -532,7 +534,7 @@ function write_term(list::List, render, node, enter)
 end
 
 function write_term(item::Item, render, node, enter)
-    if enter
+    return if enter
         if item.list_data.type === :ordered
             number = string(render.format.list_item_number[end], ". ")
             render.format.list_item_number[end] += 1
@@ -557,7 +559,7 @@ function write_term(::ThematicBreak, render, node, enter)
     stars = " § "
     padding = '═'^padding_between(available_columns(render), length(stars))
     print_literal(render, style, padding, stars, padding, inv(style), "\n")
-    if !isnull(node.nxt)
+    return if !isnull(node.nxt)
         print_margin(render)
         print_literal(render, "\n")
     end
@@ -571,7 +573,7 @@ function write_term(::CodeBlock, render, node, enter)
         print_literal(render, "  ", pipe, "│", inv(pipe), " ")
         print_literal(render, style, line, inv(style), "\n")
     end
-    if !isnull(node.nxt)
+    return if !isnull(node.nxt)
         print_margin(render)
         print_literal(render, "\n")
     end
@@ -583,7 +585,7 @@ function write_term(::HtmlBlock, render, node, enter)
         print_margin(render)
         print_literal(render, style, line, inv(style), "\n")
     end
-    if !isnull(node.nxt)
+    return if !isnull(node.nxt)
         print_margin(render)
         print_literal(render, "\n")
     end

--- a/src/writers/typst.jl
+++ b/src/writers/typst.jl
@@ -1,12 +1,12 @@
 # Public.
 
 function Base.show(
-    io::IO,
-    ::MIME"text/typst",
-    ast::Node,
-    env = Dict{String,Any}();
-    transform = default_transform,
-)
+        io::IO,
+        ::MIME"text/typst",
+        ast::Node,
+        env = Dict{String, Any}();
+        transform = default_transform,
+    )
     w = Writer(Typst(io), io, env; transform = transform)
     write_typst(w, ast)
     return nothing
@@ -32,7 +32,7 @@ typst(args...; kws...) = writer(MIME"text/typst"(), args...; kws...)
 
 mime_to_str(::MIME"text/typst") = "typst"
 
-mutable struct Typst{I<:IO}
+mutable struct Typst{I <: IO}
     buffer::I
     indent::Int
     margin::Vector{MarginSegment}
@@ -47,6 +47,7 @@ function write_typst(writer::Writer, ast::Node)
         node, entering = _transform(writer.transform, mime, node, entering, writer)
         write_typst(node.t, writer, node, entering)
     end
+    return
 end
 
 # Writers.
@@ -57,9 +58,9 @@ write_typst(::Text, w, node, ent) = typst_escape(w, node.literal)
 
 write_typst(::Backslash, w, node, ent) = literal(w, "\\")
 
-function write_typst(::Union{SoftBreak,LineBreak}, w, node, ent)
+function write_typst(::Union{SoftBreak, LineBreak}, w, node, ent)
     cr(w)
-    print_margin(w)
+    return print_margin(w)
 end
 
 function write_typst(::Code, w, node, ent)
@@ -67,7 +68,7 @@ function write_typst(::Code, w, node, ent)
     maxrun = foldl(eachmatch(r"`+", content); init = 0) do a, b
         max(a, length(b.match))
     end
-    if maxrun == 0
+    return if maxrun == 0
         literal(w, "`", content, "`")
     else
         # Typst closes a raw span at a run of N backticks and parses a language
@@ -86,7 +87,7 @@ end
 write_typst(::HtmlInline, w, node, ent) = nothing
 
 function write_typst(link::Link, w, node, ent)
-    if ent
+    return if ent
         literal(w, "#link(", repr(link.destination), ")[")
     else
         literal(w, "]")
@@ -94,7 +95,7 @@ function write_typst(link::Link, w, node, ent)
 end
 
 function write_typst(image::Image, w, node, ent)
-    if ent
+    return if ent
         literal(w, "#figure(image(", repr(image.destination), "), caption: [")
     else
         literal(w, "])")
@@ -106,7 +107,7 @@ write_typst(::Emph, w, node, ent) = literal(w, ent ? "#emph[" : "]")
 write_typst(::Strong, w, node, ent) = literal(w, ent ? "#strong[" : "]")
 
 function write_typst(::Paragraph, w, node, ent)
-    if ent
+    return if ent
         print_margin(w)
     else
         cr(w)
@@ -115,7 +116,7 @@ function write_typst(::Paragraph, w, node, ent)
 end
 
 function write_typst(heading::Heading, w, node, ent)
-    if ent
+    return if ent
         print_margin(w)
         literal(w, "="^heading.level, " ")
     else
@@ -125,7 +126,7 @@ function write_typst(heading::Heading, w, node, ent)
 end
 
 function write_typst(::BlockQuote, w, node, ent)
-    if ent
+    return if ent
         literal(w, "#quote(block: true)[")
         cr(w)
     else
@@ -135,7 +136,7 @@ function write_typst(::BlockQuote, w, node, ent)
 end
 
 function write_typst(list::List, w, node, ent)
-    if ent
+    return if ent
         w.format.list_depth += 1
         push!(w.format.list_item_number, list.list_data.start)
     else
@@ -147,7 +148,7 @@ function write_typst(list::List, w, node, ent)
 end
 
 function write_typst(item::Item, w, node, enter)
-    if enter
+    return if enter
         if item.list_data.type === :ordered
             number = lpad(string(w.format.list_item_number[end], ". "), 4, " ")
             w.format.list_item_number[end] += 1
@@ -171,7 +172,7 @@ end
 function write_typst(::ThematicBreak, w, node, ent)
     literal(w, "#line(start: (25%, 0%), end: (75%, 0%))")
     cr(w)
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
 function write_typst(code::CodeBlock, w, node, ent)
@@ -186,7 +187,7 @@ function write_typst(code::CodeBlock, w, node, ent)
     print_margin(w)
     literal(w, fence)
     cr(w)
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
 function write_typst(::HtmlBlock, w, node, ent)
@@ -194,10 +195,10 @@ function write_typst(::HtmlBlock, w, node, ent)
         print_margin(w)
         literal(w, line)
     end
-    linebreak(w, node)
+    return linebreak(w, node)
 end
 
-let chars = Dict{Char,String}()
+let chars = Dict{Char, String}()
     for c in "~\$#_"
         chars[c] = "\\$c"
     end
@@ -205,6 +206,7 @@ let chars = Dict{Char,String}()
         for ch in s
             literal(w, get(chars, ch, ch))
         end
+        return
     end
 
     global function typst_escape(s::AbstractString)

--- a/test/extensions/admonitions.jl
+++ b/test/extensions/admonitions.jl
@@ -7,36 +7,50 @@
     test_admonition = test_all_formats(pwd())
 
     # Basic warning admonition
-    test_admonition("warning_basic", p("""
-                                     !!! warning
+    test_admonition(
+        "warning_basic", p(
+            """
+            !!! warning
 
-                                         text
-                                     """), "admonitions")
+                text
+            """
+        ), "admonitions"
+    )
 
     # Warning with tab-indented content
-    test_admonition("warning_tab_indent", p("""
-                                          !!! warning
+    test_admonition(
+        "warning_tab_indent", p(
+            """
+            !!! warning
 
-                                          \ttext
-                                          """), "admonitions")
+            \ttext
+            """
+        ), "admonitions"
+    )
 
     # Info admonition with custom title
-    test_admonition("info_custom_title", p("""
-                                         !!! info "Custom Title"
+    test_admonition(
+        "info_custom_title", p(
+            """
+            !!! info "Custom Title"
 
-                                             text
-                                         """), "admonitions")
+                text
+            """
+        ), "admonitions"
+    )
 
     # Warning with attributes (id)
     p_with_attrs = create_parser([AdmonitionRule(), AttributeRule()])
     test_admonition(
         "warning_with_id",
-        p_with_attrs("""
-        {#id}
-        !!! warning
+        p_with_attrs(
+            """
+            {#id}
+            !!! warning
 
-            text
-        """),
+                text
+            """
+        ),
         "admonitions",
         formats = [:html, :latex],
     )

--- a/test/extensions/attributes.jl
+++ b/test/extensions/attributes.jl
@@ -13,31 +13,31 @@
         @test ast.first_child.t.dict == dict
     end
 
-    test("{}", Dict{String,Any}())
-    test("{empty}", Dict{String,Any}("empty" => ""))
-    test("{#id}", Dict{String,Any}("id" => "id"))
-    test("{empty #id}", Dict{String,Any}("id" => "id", "empty" => ""))
-    test("{#id empty}", Dict{String,Any}("id" => "id", "empty" => ""))
-    test("{#one #two}", Dict{String,Any}("id" => "two")) # Only last # is kept.
-    test("{.class}", Dict{String,Any}("class" => ["class"]))
-    test("{empty .class}", Dict{String,Any}("class" => ["class"], "empty" => ""))
-    test("{.one.two}", Dict{String,Any}("class" => ["one", "two"])) # All .s are kept.
-    test("{:element}", Dict{String,Any}("element" => "element"))
-    test("{:element empty}", Dict{String,Any}("element" => "element", "empty" => ""))
-    test("{one=two}", Dict{String,Any}("one" => "two"))
+    test("{}", Dict{String, Any}())
+    test("{empty}", Dict{String, Any}("empty" => ""))
+    test("{#id}", Dict{String, Any}("id" => "id"))
+    test("{empty #id}", Dict{String, Any}("id" => "id", "empty" => ""))
+    test("{#id empty}", Dict{String, Any}("id" => "id", "empty" => ""))
+    test("{#one #two}", Dict{String, Any}("id" => "two")) # Only last # is kept.
+    test("{.class}", Dict{String, Any}("class" => ["class"]))
+    test("{empty .class}", Dict{String, Any}("class" => ["class"], "empty" => ""))
+    test("{.one.two}", Dict{String, Any}("class" => ["one", "two"])) # All .s are kept.
+    test("{:element}", Dict{String, Any}("element" => "element"))
+    test("{:element empty}", Dict{String, Any}("element" => "element", "empty" => ""))
+    test("{one=two}", Dict{String, Any}("one" => "two"))
     test(
         "{empty one=two other}",
-        Dict{String,Any}("one" => "two", "empty" => "", "other" => ""),
+        Dict{String, Any}("one" => "two", "empty" => "", "other" => ""),
     )
-    test("{one=two three='four'}", Dict{String,Any}("one" => "two", "three" => "four"))
+    test("{one=two three='four'}", Dict{String, Any}("one" => "two", "three" => "four"))
     test(
         "{one=two empty three='four'}",
-        Dict{String,Any}("one" => "two", "three" => "four", "empty" => ""),
+        Dict{String, Any}("one" => "two", "three" => "four", "empty" => ""),
     )
-    test("{one=2 three=4}", Dict{String,Any}("one" => "2", "three" => "4"))
+    test("{one=2 three=4}", Dict{String, Any}("one" => "2", "three" => "4"))
     test(
         "{#id .class one=two three='four'}",
-        Dict{String,Any}(
+        Dict{String, Any}(
             "id" => "id",
             "class" => ["class"],
             "one" => "two",
@@ -54,7 +54,7 @@
         @test ast.first_child.nxt.meta == dict
         @test text == markdown(ast)
     end
-    dict = Dict{String,Any}("id" => "id")
+    dict = Dict{String, Any}("id" => "id")
 
     test(
         """
@@ -114,7 +114,7 @@
           - list
         """,
         CommonMark.List,
-        Dict{String,Any}("class" => ["hidden"]),
+        Dict{String, Any}("class" => ["hidden"]),
     )
 
     # Inline metadata attachment.

--- a/test/extensions/citations.jl
+++ b/test/extensions/citations.jl
@@ -9,7 +9,7 @@
     test_citations = test_all_formats(pwd())
 
     function test(bib, ast, base_name)
-        env = Dict{String,Any}("references" => bib)
+        env = Dict{String, Any}("references" => bib)
         test_citations(base_name, ast, "citations", env = env)
     end
 
@@ -65,8 +65,8 @@
     p = create_parser([CitationRule(), AttributeRule()])
 
     text = """
-           {#refs}
-           # The reference list.
-           """
+    {#refs}
+    # The reference list.
+    """
     test(bib, p(text), "reference_list")
 end

--- a/test/extensions/definitionlists.jl
+++ b/test/extensions/definitionlists.jl
@@ -65,15 +65,15 @@
     # Roundtrip test
     @testset "markdown roundtrip" begin
         for input in [
-            "Term\n:   Definition\n",
-            "Term\n:   Definition 1\n:   Definition 2\n",
-            "Term 1\n:   Definition 1\n\nTerm 2\n:   Definition 2\n",
-            "Term\n\n:   Definition\n",
-            "*Emphasized* term\n:   Definition\n",
-            "Term\n:   Paragraph 1\n\n    Paragraph 2\n",
-            "Term\n:   Definition\n\n    - item 1\n    - item 2\n",
-            "> Term\n> :   Definition\n",
-        ]
+                "Term\n:   Definition\n",
+                "Term\n:   Definition 1\n:   Definition 2\n",
+                "Term 1\n:   Definition 1\n\nTerm 2\n:   Definition 2\n",
+                "Term\n\n:   Definition\n",
+                "*Emphasized* term\n:   Definition\n",
+                "Term\n:   Paragraph 1\n\n    Paragraph 2\n",
+                "Term\n:   Definition\n\n    - item 1\n    - item 2\n",
+                "> Term\n> :   Definition\n",
+            ]
             ast = p(input)
             md1 = markdown(ast)
             md2 = markdown(p(md1))

--- a/test/extensions/delimiter_interactions.jl
+++ b/test/extensions/delimiter_interactions.jl
@@ -31,7 +31,7 @@
     @test html(p("^**bold super**^")) == "<p><sup><strong>bold super</strong></sup></p>\n"
     @test html(p("*~sub in italic~*")) == "<p><em><sub>sub in italic</sub></em></p>\n"
     @test html(p("**^super in bold^**")) ==
-          "<p><strong><sup>super in bold</sup></strong></p>\n"
+        "<p><strong><sup>super in bold</sup></strong></p>\n"
 
     # ==========================================
     # Three-level nesting

--- a/test/extensions/fenceddivs.jl
+++ b/test/extensions/fenceddivs.jl
@@ -8,47 +8,47 @@
 
     # Basic div with bare word class
     @test html(p("::: warning\nContent\n:::")) ==
-          "<div class=\"warning\">\n<p>Content</p>\n</div>\n"
+        "<div class=\"warning\">\n<p>Content</p>\n</div>\n"
 
     # Div with full attribute syntax
     @test html(p("::: {#myid .note}\nContent\n:::")) ==
-          "<div class=\"note\" id=\"myid\">\n<p>Content</p>\n</div>\n"
+        "<div class=\"note\" id=\"myid\">\n<p>Content</p>\n</div>\n"
 
     # Multiple classes
     @test html(p("::: {.note .important}\nContent\n:::")) ==
-          "<div class=\"note important\">\n<p>Content</p>\n</div>\n"
+        "<div class=\"note important\">\n<p>Content</p>\n</div>\n"
 
     # Bare word with multiple classes
     @test html(p("::: warning important\nContent\n:::")) ==
-          "<div class=\"warning important\">\n<p>Content</p>\n</div>\n"
+        "<div class=\"warning important\">\n<p>Content</p>\n</div>\n"
 
     # Key-value attribute
     @test html(p("::: {.note data-info=\"test\"}\nContent\n:::")) ==
-          "<div class=\"note\" data-info=\"test\">\n<p>Content</p>\n</div>\n"
+        "<div class=\"note\" data-info=\"test\">\n<p>Content</p>\n</div>\n"
 
     # Nested divs
     @test html(p("::: outer\nBefore\n::: inner\nNested\n:::\nAfter\n:::")) ==
-          "<div class=\"outer\">\n<p>Before</p>\n<div class=\"inner\">\n<p>Nested</p>\n</div>\n<p>After</p>\n</div>\n"
+        "<div class=\"outer\">\n<p>Before</p>\n<div class=\"inner\">\n<p>Nested</p>\n</div>\n<p>After</p>\n</div>\n"
 
     # Longer fence for nesting clarity
     @test html(p(":::: outer\nBefore\n::: inner\nNested\n:::\nAfter\n::::")) ==
-          "<div class=\"outer\">\n<p>Before</p>\n<div class=\"inner\">\n<p>Nested</p>\n</div>\n<p>After</p>\n</div>\n"
+        "<div class=\"outer\">\n<p>Before</p>\n<div class=\"inner\">\n<p>Nested</p>\n</div>\n<p>After</p>\n</div>\n"
 
     # Closing fence must match or exceed opening length
     @test html(p(":::: warning\nContent\n::::")) ==
-          "<div class=\"warning\">\n<p>Content</p>\n</div>\n"
+        "<div class=\"warning\">\n<p>Content</p>\n</div>\n"
 
     # Multi-paragraph content
     @test html(p("::: note\nPara 1\n\nPara 2\n:::")) ==
-          "<div class=\"note\">\n<p>Para 1</p>\n<p>Para 2</p>\n</div>\n"
+        "<div class=\"note\">\n<p>Para 1</p>\n<p>Para 2</p>\n</div>\n"
 
     # Div with code block inside
     @test html(p("::: example\n```\ncode\n```\n:::")) ==
-          "<div class=\"example\">\n<pre><code>code\n</code></pre>\n</div>\n"
+        "<div class=\"example\">\n<pre><code>code\n</code></pre>\n</div>\n"
 
     # Div with blockquote inside
     @test html(p("::: note\n> quoted\n:::")) ==
-          "<div class=\"note\">\n<blockquote>\n<p>quoted</p>\n</blockquote>\n</div>\n"
+        "<div class=\"note\">\n<blockquote>\n<p>quoted</p>\n</blockquote>\n</div>\n"
 
     # Bare colons without attributes = not a div
     @test html(p(":::\nContent\n:::")) == "<p>:::\nContent\n:::</p>\n"
@@ -65,11 +65,11 @@
 
     # Markdown roundtrip - full attributes
     @test markdown(p("::: {#myid .note}\nContent\n:::")) ==
-          "::: {#myid .note}\nContent\n:::\n"
+        "::: {#myid .note}\nContent\n:::\n"
 
     # Markdown roundtrip - nested (paragraphs get blank line separation)
     @test markdown(p("::: outer\nBefore\n::: inner\nNested\n:::\nAfter\n:::")) ==
-          "::: outer\nBefore\n\n::: inner\nNested\n:::\n\nAfter\n:::\n"
+        "::: outer\nBefore\n\n::: inner\nNested\n:::\n\nAfter\n:::\n"
 
     # Reference tests
     test_div("basic_warning", p("::: warning\nThis is a warning.\n:::"), "fenceddivs")
@@ -80,27 +80,35 @@
         "fenceddivs",
     )
 
-    test_div("nested", p("""
-        ::: outer
-        Outer content.
+    test_div(
+        "nested", p(
+            """
+            ::: outer
+            Outer content.
 
-        ::: inner
-        Inner content.
-        :::
+            ::: inner
+            Inner content.
+            :::
 
-        More outer.
-        :::
-        """), "fenceddivs")
+            More outer.
+            :::
+            """
+        ), "fenceddivs"
+    )
 
-    test_div("with_code", p("""
-        ::: example
-        Here is some code:
+    test_div(
+        "with_code", p(
+            """
+            ::: example
+            Here is some code:
 
-        ```julia
-        println("Hello")
-        ```
-        :::
-        """), "fenceddivs")
+            ```julia
+            println("Hello")
+            ```
+            :::
+            """
+        ), "fenceddivs"
+    )
 
     test_div(
         "multiclass",

--- a/test/extensions/footnotes.jl
+++ b/test/extensions/footnotes.jl
@@ -32,10 +32,12 @@
     # Definition with attributes
     test_footnote(
         "definition_with_attrs",
-        p_with_attrs("""
-{key="value"}
-[^1]: text
-"""),
+        p_with_attrs(
+            """
+            {key="value"}
+            [^1]: text
+            """
+        ),
         "footnotes",
         formats = [:html],
     )
@@ -43,12 +45,14 @@
     # Full footnote with attributes
     test_footnote(
         "full_with_attrs",
-        p_with_attrs("""
-text[^1]{#id}.
+        p_with_attrs(
+            """
+            text[^1]{#id}.
 
-{key="value"}
-[^1]: text
-"""),
+            {key="value"}
+            [^1]: text
+            """
+        ),
         "footnotes",
         formats = [:html, :latex, :typst],
     )

--- a/test/extensions/frontmatter.jl
+++ b/test/extensions/frontmatter.jl
@@ -51,10 +51,10 @@
 
     # Unclosed frontmatter. Runs on until EOF.
     text = """
-           +++
-           one = 1
-           two = 2
-           """
+    +++
+    one = 1
+    two = 2
+    """
     ast = p(text)
     data = frontmatter(ast)
     @test data["one"] == 1
@@ -65,10 +65,10 @@
     test_single("references/frontmatter/not_first_line.html.txt", text, html)
 
     text = """
-           ---
-           field: data
-           ---
-           """
+    ---
+    field: data
+    ---
+    """
     ast = p(text)
     @test markdown(ast) == "---\nfield: data\n---\n"
     @test markdown(p(markdown(ast))) == markdown(ast)

--- a/test/extensions/github_alerts.jl
+++ b/test/extensions/github_alerts.jl
@@ -8,60 +8,60 @@
 
     # Basic NOTE alert
     @test html(p("> [!NOTE]\n> Content here")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Content here</p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Content here</p>\n</div>\n"
 
     # All 5 alert types
     @test html(p("> [!TIP]\n> Tip content")) ==
-          "<div class=\"github-alert tip\"><p class=\"github-alert-title\">Tip</p>\n<p>Tip content</p>\n</div>\n"
+        "<div class=\"github-alert tip\"><p class=\"github-alert-title\">Tip</p>\n<p>Tip content</p>\n</div>\n"
 
     @test html(p("> [!IMPORTANT]\n> Important content")) ==
-          "<div class=\"github-alert important\"><p class=\"github-alert-title\">Important</p>\n<p>Important content</p>\n</div>\n"
+        "<div class=\"github-alert important\"><p class=\"github-alert-title\">Important</p>\n<p>Important content</p>\n</div>\n"
 
     @test html(p("> [!WARNING]\n> Warning content")) ==
-          "<div class=\"github-alert warning\"><p class=\"github-alert-title\">Warning</p>\n<p>Warning content</p>\n</div>\n"
+        "<div class=\"github-alert warning\"><p class=\"github-alert-title\">Warning</p>\n<p>Warning content</p>\n</div>\n"
 
     @test html(p("> [!CAUTION]\n> Caution content")) ==
-          "<div class=\"github-alert caution\"><p class=\"github-alert-title\">Caution</p>\n<p>Caution content</p>\n</div>\n"
+        "<div class=\"github-alert caution\"><p class=\"github-alert-title\">Caution</p>\n<p>Caution content</p>\n</div>\n"
 
     # Case insensitivity
     @test html(p("> [!note]\n> lowercase")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>lowercase</p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>lowercase</p>\n</div>\n"
 
     @test html(p("> [!Note]\n> mixed case")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>mixed case</p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>mixed case</p>\n</div>\n"
 
     # Multi-line content
     @test html(p("> [!NOTE]\n> Line 1\n> Line 2")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Line 1\nLine 2</p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Line 1\nLine 2</p>\n</div>\n"
 
     # Content with inline formatting
     @test html(p("> [!NOTE]\n> **bold** and *italic*")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p><strong>bold</strong> and <em>italic</em></p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p><strong>bold</strong> and <em>italic</em></p>\n</div>\n"
 
     # Regular blockquote unchanged
     p_no_ext = create_parser()
     @test html(p_no_ext("> [!NOTE]\n> Content")) ==
-          "<blockquote>\n<p>[!NOTE]\nContent</p>\n</blockquote>\n"
+        "<blockquote>\n<p>[!NOTE]\nContent</p>\n</blockquote>\n"
 
     # Non-matching blockquote (not an alert type) unchanged
     @test html(p("> [!UNKNOWN]\n> Content")) ==
-          "<blockquote>\n<p>[!UNKNOWN]\nContent</p>\n</blockquote>\n"
+        "<blockquote>\n<p>[!UNKNOWN]\nContent</p>\n</blockquote>\n"
 
     # Regular blockquote unchanged
     @test html(p("> Regular quote")) ==
-          "<blockquote>\n<p>Regular quote</p>\n</blockquote>\n"
+        "<blockquote>\n<p>Regular quote</p>\n</blockquote>\n"
 
     # Content on same line as marker
     @test html(p("> [!NOTE] Same line content")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Same line content</p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Same line content</p>\n</div>\n"
 
     # Alert with code block inside
     @test html(p("> [!NOTE]\n> ```\n> code\n> ```")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<pre><code>code\n</code></pre>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<pre><code>code\n</code></pre>\n</div>\n"
 
     # Alert with link
     @test html(p("> [!NOTE]\n> [link](url)")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p><a href=\"url\">link</a></p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p><a href=\"url\">link</a></p>\n</div>\n"
 
     # Terminal rendering
     @test occursin("Note", term(p("> [!NOTE]\n> Content")))
@@ -73,45 +73,57 @@
 
     # Multiple paragraphs in alert
     @test html(p("> [!NOTE]\n> Para 1\n>\n> Para 2")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Para 1</p>\n<p>Para 2</p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>Para 1</p>\n<p>Para 2</p>\n</div>\n"
 
     # Blank line immediately after marker (marker-only first paragraph gets unlinked)
     @test html(p("> [!TIP]\n>\n> Content here")) ==
-          "<div class=\"github-alert tip\"><p class=\"github-alert-title\">Tip</p>\n<p>Content here</p>\n</div>\n"
+        "<div class=\"github-alert tip\"><p class=\"github-alert-title\">Tip</p>\n<p>Content here</p>\n</div>\n"
     @test markdown(p("> [!TIP]\n>\n> Content here")) == "> [!TIP]\n> Content here\n"
 
     # No interference with link references
     # [!NOTE] should not conflict with link reference syntax [text]: url
     p_linkref = create_parser(ReferenceLinkRule())
     @test html(p_linkref("> Regular [link][ref]\n\n[ref]: url")) ==
-          "<blockquote>\n<p>Regular <a href=\"url\">link</a></p>\n</blockquote>\n"
+        "<blockquote>\n<p>Regular <a href=\"url\">link</a></p>\n</blockquote>\n"
 
     # Alert with link reference should work
     p_both = create_parser([GitHubAlertRule(), ReferenceLinkRule()])
     @test html(p_both("> [!NOTE]\n> See [link][ref]\n\n[ref]: url")) ==
-          "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>See <a href=\"url\">link</a></p>\n</div>\n"
+        "<div class=\"github-alert note\"><p class=\"github-alert-title\">Note</p>\n<p>See <a href=\"url\">link</a></p>\n</div>\n"
 
     # Reference tests for all formats
     test_alert("note_basic", p("> [!NOTE]\n> Basic note content."), "github_alerts")
 
-    test_alert("note_multiline", p("""
-        > [!NOTE]
-        > Line one.
-        > Line two.
-        > Line three.
-        """), "github_alerts")
+    test_alert(
+        "note_multiline", p(
+            """
+            > [!NOTE]
+            > Line one.
+            > Line two.
+            > Line three.
+            """
+        ), "github_alerts"
+    )
 
-    test_alert("note_multipara", p("""
-        > [!NOTE]
-        > First paragraph.
-        >
-        > Second paragraph.
-        """), "github_alerts")
+    test_alert(
+        "note_multipara", p(
+            """
+            > [!NOTE]
+            > First paragraph.
+            >
+            > Second paragraph.
+            """
+        ), "github_alerts"
+    )
 
-    test_alert("warning_formatted", p("""
-        > [!WARNING]
-        > This has **bold**, *italic*, and `code`.
-        """), "github_alerts")
+    test_alert(
+        "warning_formatted", p(
+            """
+            > [!WARNING]
+            > This has **bold**, *italic*, and `code`.
+            """
+        ), "github_alerts"
+    )
 
     test_alert(
         "tip_with_link",
@@ -120,11 +132,15 @@
     )
 
     # Blank line after marker - tests unlink during iteration fix
-    test_alert("tip_blank_after_marker", p("""
-        > [!TIP]
-        >
-        > Here is some **bold** and *italic* content.
-        >
-        > And a second paragraph with a [link](https://example.com).
-        """), "github_alerts")
+    test_alert(
+        "tip_blank_after_marker", p(
+            """
+            > [!TIP]
+            >
+            > Here is some **bold** and *italic* content.
+            >
+            > And a second paragraph with a [link](https://example.com).
+            """
+        ), "github_alerts"
+    )
 end

--- a/test/extensions/grid_tables.jl
+++ b/test/extensions/grid_tables.jl
@@ -9,12 +9,12 @@
 
     # Basic header + body
     text = """
-           +-------+-------+
-           | Head1 | Head2 |
-           +=======+=======+
-           | Body1 | Body2 |
-           +-------+-------+
-           """
+    +-------+-------+
+    | Head1 | Head2 |
+    +=======+=======+
+    | Body1 | Body2 |
+    +-------+-------+
+    """
     ast = p(text)
     test_grid("basic", ast, "grid_tables")
 
@@ -25,38 +25,38 @@
 
     # Body-only (no header separator)
     text = """
-           +-------+-------+
-           | Left  | Right |
-           +-------+-------+
-           """
+    +-------+-------+
+    | Left  | Right |
+    +-------+-------+
+    """
     ast = p(text)
     test_grid("body_only", ast, "grid_tables")
 
     # Multi-line cells
     text = """
-           +----------+----------+
-           | Line one | Single   |
-           | Line two |          |
-           +==========+==========+
-           | Body     | Multi    |
-           |          | line too |
-           +----------+----------+
-           """
+    +----------+----------+
+    | Line one | Single   |
+    | Line two |          |
+    +==========+==========+
+    | Body     | Multi    |
+    |          | line too |
+    +----------+----------+
+    """
     ast = p(text)
     test_grid("multiline", ast, "grid_tables")
 
     # Colspan header (Temperature table) with rowspan
     text = """
-           +----------+----------------------+
-           | Location | Temperature          |
-           |          +------+------+--------+
-           |          | min  | mean | max    |
-           +==========+======+======+========+
-           | Chicago  | -10  | 15   | 35     |
-           +----------+------+------+--------+
-           | Berlin   | -5   | 12   | 30     |
-           +----------+------+------+--------+
-           """
+    +----------+----------------------+
+    | Location | Temperature          |
+    |          +------+------+--------+
+    |          | min  | mean | max    |
+    +==========+======+======+========+
+    | Chicago  | -10  | 15   | 35     |
+    +----------+------+------+--------+
+    | Berlin   | -5   | 12   | 30     |
+    +----------+------+------+--------+
+    """
     ast = p(text)
     test_grid("colspan_header", ast, "grid_tables")
 
@@ -108,12 +108,12 @@
 
     # Simple colspan in body
     text = """
-           +------+------+------+
-           | A    | B    | C    |
-           +------+------+------+
-           | wide span   | solo |
-           +------+------+------+
-           """
+    +------+------+------+
+    | A    | B    | C    |
+    +------+------+------+
+    | wide span   | solo |
+    +------+------+------+
+    """
     ast = p(text)
     test_grid("colspan_body", ast, "grid_tables")
 
@@ -123,14 +123,14 @@
 
     # Header + body + footer (enclosed = separators)
     text = """
-           +-------+-------+
-           | Head1 | Head2 |
-           +=======+=======+
-           | Body1 | Body2 |
-           +=======+=======+
-           | Foot1 | Foot2 |
-           +=======+=======+
-           """
+    +-------+-------+
+    | Head1 | Head2 |
+    +=======+=======+
+    | Body1 | Body2 |
+    +=======+=======+
+    | Foot1 | Foot2 |
+    +=======+=======+
+    """
     ast = p(text)
     test_grid("footer", ast, "grid_tables")
 
@@ -152,14 +152,14 @@
 
     # Non-enclosed = at end should NOT create footer
     text = """
-           +-------+-------+
-           | Head1 | Head2 |
-           +=======+=======+
-           | Body1 | Body2 |
-           +-------+-------+
-           | Row2  | Row2  |
-           +=======+=======+
-           """
+    +-------+-------+
+    | Head1 | Head2 |
+    +=======+=======+
+    | Body1 | Body2 |
+    +-------+-------+
+    | Row2  | Row2  |
+    +=======+=======+
+    """
     ast = p(text)
     let sections = CommonMark.Node[]
         n = ast.first_child.first_child
@@ -174,14 +174,14 @@
 
     # Footer with colspan
     text = """
-           +------+------+------+
-           | H1   | H2   | H3   |
-           +======+======+======+
-           | B1   | B2   | B3   |
-           +======+=============+
-           | F1   | F2 spanning |
-           +======+=============+
-           """
+    +------+------+------+
+    | H1   | H2   | H3   |
+    +======+======+======+
+    | B1   | B2   | B3   |
+    +======+=============+
+    | F1   | F2 spanning |
+    +======+=============+
+    """
     ast = p(text)
     let sections = CommonMark.Node[]
         n = ast.first_child.first_child
@@ -204,16 +204,16 @@
 
     # Footer with rowspan
     text = """
-           +------+------+
-           | H1   | H2   |
-           +======+======+
-           | B1   | B2   |
-           +======+======+
-           | F1   | FA   |
-           |      +------+
-           |      | FB   |
-           +======+======+
-           """
+    +------+------+
+    | H1   | H2   |
+    +======+======+
+    | B1   | B2   |
+    +======+======+
+    | F1   | FA   |
+    |      +------+
+    |      | FB   |
+    +======+======+
+    """
     ast = p(text)
     let sections = CommonMark.Node[]
         n = ast.first_child.first_child
@@ -237,10 +237,10 @@
 
     # Round-trip all previous tests
     for input in [
-        "+-------+-------+\n| Head1 | Head2 |\n+=======+=======+\n| Body1 | Body2 |\n+-------+-------+\n",
-        "+-------+-------+\n| Left  | Right |\n+-------+-------+\n",
-        "+----------+----------+\n| Line one | Single   |\n| Line two |          |\n+==========+==========+\n| Body     | Multi    |\n|          | line too |\n+----------+----------+\n",
-    ]
+            "+-------+-------+\n| Head1 | Head2 |\n+=======+=======+\n| Body1 | Body2 |\n+-------+-------+\n",
+            "+-------+-------+\n| Left  | Right |\n+-------+-------+\n",
+            "+----------+----------+\n| Line one | Single   |\n| Line two |          |\n+==========+==========+\n| Body     | Multi    |\n|          | line too |\n+----------+----------+\n",
+        ]
         local ast = p(input)
         local md1 = markdown(ast)
         local md2 = markdown(p(md1))
@@ -249,16 +249,16 @@
 
     # Width-80 explicit IOContext matches term() output (which uses IOBuffer → 80 cols)
     text = """
-           +----------+----------------------+
-           | Location | Temperature          |
-           |          +------+------+--------+
-           |          | min  | mean | max    |
-           +==========+======+======+========+
-           | Chicago  | -10  | 15   | 35     |
-           +----------+------+------+--------+
-           | Berlin   | -5   | 12   | 30     |
-           +----------+------+------+--------+
-           """
+    +----------+----------------------+
+    | Location | Temperature          |
+    |          +------+------+--------+
+    |          | min  | mean | max    |
+    +==========+======+======+========+
+    | Chicago  | -10  | 15   | 35     |
+    +----------+------+------+--------+
+    | Berlin   | -5   | 12   | 30     |
+    +----------+------+------+--------+
+    """
     ast = p(text)
     buf80 = IOBuffer()
     show(IOContext(buf80, :displaysize => (24, 80)), MIME"text/plain"(), ast)
@@ -266,13 +266,13 @@
 
     # Narrow terminal wraps content — all visible lines ≤ target width
     text = """
-           +----------+------------------------------------------------+
-           | Key      | Value                                          |
-           +==========+================================================+
-           | greeting | Hello world, this is a rather long piece of    |
-           |          | text that should wrap when the terminal is narrow|
-           +----------+------------------------------------------------+
-           """
+    +----------+------------------------------------------------+
+    | Key      | Value                                          |
+    +==========+================================================+
+    | greeting | Hello world, this is a rather long piece of    |
+    |          | text that should wrap when the terminal is narrow|
+    +----------+------------------------------------------------+
+    """
     ast = p(text)
     narrow_width = 40
     buf = IOBuffer()
@@ -299,16 +299,16 @@
 
     # Nested grid table inside a cell
     text = """
-           +-------------------------+-------------------+
-           | Outer Left              | Outer Right       |
-           +=========================+===================+
-           | +------+------+         | Regular cell      |
-           | | A    | B    |         |                   |
-           | +------+------+         |                   |
-           | | C    | D    |         |                   |
-           | +------+------+         |                   |
-           +-------------------------+-------------------+
-           """
+    +-------------------------+-------------------+
+    | Outer Left              | Outer Right       |
+    +=========================+===================+
+    | +------+------+         | Regular cell      |
+    | | A    | B    |         |                   |
+    | +------+------+         |                   |
+    | | C    | D    |         |                   |
+    | +------+------+         |                   |
+    +-------------------------+-------------------+
+    """
     ast = p(text)
     # Outer table should have 2 columns
     table = ast.first_child
@@ -327,35 +327,35 @@
     # Grid table with TableRule enabled — no extra empty columns from pipe inline_modifier
     p_both = create_parser([GridTableRule(), TableRule()])
     text = """
-           +-------+-------+
-           | Head1 | Head2 |
-           +=======+=======+
-           | Body1 | Body2 |
-           +-------+-------+
-           """
+    +-------+-------+
+    | Head1 | Head2 |
+    +=======+=======+
+    | Body1 | Body2 |
+    +-------+-------+
+    """
     ast = p_both(text)
     cells = [n for (n, e) in ast if e && n.t isa CommonMark.TableCell]
     @test length(cells) == 4  # 2 header + 2 body, no extras
 
     # Unicode (CJK) content — multi-byte chars must not cause StringIndexError
     text = """
-           +------------+------+
-           | こんにちは | 世界 |
-           +============+======+
-           | テスト     | OK   |
-           +------------+------+
-           """
+    +------------+------+
+    | こんにちは | 世界 |
+    +============+======+
+    | テスト     | OK   |
+    +------------+------+
+    """
     ast = p(text)
     test_grid("unicode_cjk", ast, "grid_tables")
 
     # Colspan cell at narrow width wraps at combined target
     text = """
-           +------+------+------+
-           | A    | B    | C    |
-           +------+------+------+
-           | wide span   | solo |
-           +------+------+------+
-           """
+    +------+------+------+
+    | A    | B    | C    |
+    +------+------+------+
+    | wide span   | solo |
+    +------+------+------+
+    """
     ast = p(text)
     buf = IOBuffer()
     show(IOContext(buf, :displaysize => (24, 35)), MIME"text/plain"(), ast)

--- a/test/extensions/highlights.jl
+++ b/test/extensions/highlights.jl
@@ -31,10 +31,10 @@
     test_highlight = test_all_formats(pwd())
 
     text = """
-            ```julia
-            code
-            ```
-            """
+    ```julia
+    code
+    ```
+    """
     ast = p(text)
 
     # Test with custom syntax highlighter

--- a/test/extensions/interpolation.jl
+++ b/test/extensions/interpolation.jl
@@ -57,20 +57,20 @@
     test_interpolation("interpolated_string", ast, "interpolation")
 
     # Interpolated values are not linked to their macroexpansion origin.
-    asts = [cm"Value = **$(each)**" for each = 1:3]
+    asts = [cm"Value = **$(each)**" for each in 1:3]
     test_interpolation("interpolated_values_1", asts[1], "interpolation")
     test_interpolation("interpolated_values_2", asts[2], "interpolation")
     test_interpolation("interpolated_values_3", asts[3], "interpolation")
 
     # Interpolating collections.
-    worlds = [HTML("<div>world $i</div>") for i = 1:3]
+    worlds = [HTML("<div>world $i</div>") for i in 1:3]
     test_interpolation("interpolated_collection", cm"Hello $(worlds)", "interpolation")
 
-    worlds = (HTML("<div>world $i</div>") for i = 1:3)
+    worlds = (HTML("<div>world $i</div>") for i in 1:3)
     @test html(cm"Hello $(worlds)") ==
-          "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
+        "<p>Hello <span class=\"julia-value\"><div>world 1</div> <div>world 2</div> <div>world 3</div> </span></p>\n"
 
-    worlds = Tuple(HTML("<div>world $i</div>") for i = 1:3)
+    worlds = Tuple(HTML("<div>world $i</div>") for i in 1:3)
     test_interpolation("interpolated_tuple", cm"Hello $(worlds)", "interpolation")
 
     # Make sure that the evaluation of values happens at runtime.

--- a/test/extensions/mark.jl
+++ b/test/extensions/mark.jl
@@ -16,7 +16,7 @@
     @test html(p("==*italic*==")) == "<p><mark><em>italic</em></mark></p>\n"
     @test html(p("*==italic marked==*")) == "<p><em><mark>italic marked</mark></em></p>\n"
     @test html(p("**==bold marked==**")) ==
-          "<p><strong><mark>bold marked</mark></strong></p>\n"
+        "<p><strong><mark>bold marked</mark></strong></p>\n"
 
     # Single equals - not mark (common in assignments, comparisons)
     @test html(p("a = b")) == "<p>a = b</p>\n"
@@ -42,7 +42,7 @@
 
     # Multiple in paragraph
     @test html(p("==first== and ==second==")) ==
-          "<p><mark>first</mark> and <mark>second</mark></p>\n"
+        "<p><mark>first</mark> and <mark>second</mark></p>\n"
 
     # Three equals - middle one should be part of content
     @test html(p("a===b===c")) == "<p>a=<mark>b</mark>=c</p>\n"
@@ -50,9 +50,9 @@
     # Combined with other inline extensions
     p2 = create_parser([MarkRule(), StrikethroughRule()])
     @test html(p2("==mark== and ~~strike~~")) ==
-          "<p><mark>mark</mark> and <del>strike</del></p>\n"
+        "<p><mark>mark</mark> and <del>strike</del></p>\n"
     @test html(p2("~~struck ==marked== text~~")) ==
-          "<p><del>struck <mark>marked</mark> text</del></p>\n"
+        "<p><del>struck <mark>marked</mark> text</del></p>\n"
 
     # LaTeX output
     @test latex(p("==highlighted==")) == "\\hl{highlighted}\\par\n"

--- a/test/extensions/math.jl
+++ b/test/extensions/math.jl
@@ -28,35 +28,35 @@
     text = "Some ``math``{key='value'}."
     ast = p(text)
     @test html(ast) ==
-          "<p>Some <span class=\"math tex\" key=\"value\">\\(math\\)</span>.</p>\n"
+        "<p>Some <span class=\"math tex\" key=\"value\">\\(math\\)</span>.</p>\n"
 
     # Display math with id
     text = """
-           {#id}
-           ```math
-           math
-           ```
-           """
+    {#id}
+    ```math
+    math
+    ```
+    """
     ast = p(text)
     test_math("display_math_with_id", ast, "math")
 
     # Display math with class
     text = """
-           {.red}
-           ```math
-           E=mc^2
-           ```
-           """
+    {.red}
+    ```math
+    E=mc^2
+    ```
+    """
     ast = p(text)
     @test html(ast) == "<div class=\"display-math tex red\">\\[E=mc^2\\]</div>"
 
     # Display math with id and class
     text = """
-           {#id .red}
-           ```math
-           E=mc^2
-           ```
-           """
+    {#id .red}
+    ```math
+    E=mc^2
+    ```
+    """
     ast = p(text)
     @test html(ast) == "<div class=\"display-math tex red\" id=\"id\">\\[E=mc^2\\]</div>"
 

--- a/test/extensions/raw.jl
+++ b/test/extensions/raw.jl
@@ -14,19 +14,19 @@
 
     # Block raw content
     text = """
-           ```{=html}
-           <div id="main">
-            <div class="article">
-           ```
-           ```{=latex}
-           \\begin{tikzpicture}
-           ...
-           \\end{tikzpicture}
-           ```
-           ```{=typst}
-           #let name = "Typst"
-           ```
-           """
+    ```{=html}
+    <div id="main">
+     <div class="article">
+    ```
+    ```{=latex}
+    \\begin{tikzpicture}
+    ...
+    \\end{tikzpicture}
+    ```
+    ```{=typst}
+    #let name = "Typst"
+    ```
+    """
     ast = p(text)
     test_raw("block_raw", ast, "raw")
 

--- a/test/extensions/referencelinks.jl
+++ b/test/extensions/referencelinks.jl
@@ -114,15 +114,17 @@
     @test markdown(ast) == "[text](/url)\n"  # converted to inline
 
     # All three styles together
-    ast = p("""
-[full][label]
-[collapsed][]
-[shortcut]
+    ast = p(
+        """
+        [full][label]
+        [collapsed][]
+        [shortcut]
 
-[label]: /url1
-[collapsed]: /url2
-[shortcut]: /url3
-""")
+        [label]: /url1
+        [collapsed]: /url2
+        [shortcut]: /url3
+        """
+    )
     md = markdown(ast)
     @test occursin("[full][label]", md)
     @test occursin("[collapsed][]", md)

--- a/test/extensions/shortcodes.jl
+++ b/test/extensions/shortcodes.jl
@@ -16,7 +16,7 @@
         @test ast.first_child.t isa CommonMark.ShortcodeBlock
         @test ast.first_child.t.name == "pagebreak"
         @test ast.first_child.t.args == String[]
-        @test ast.first_child.t.kwargs == Pair{String,String}[]
+        @test ast.first_child.t.kwargs == Pair{String, String}[]
     end
 
     @testset "block with surrounding whitespace" begin
@@ -41,7 +41,7 @@
         ast = p("{{< pagebreak >}}")
         @test ast.first_child.t.name == "pagebreak"
         @test ast.first_child.t.args == String[]
-        @test ast.first_child.t.kwargs == Pair{String,String}[]
+        @test ast.first_child.t.kwargs == Pair{String, String}[]
     end
 
     @testset "with args" begin
@@ -102,7 +102,7 @@
         ast = p("{{< ref page anchor >}}")
         sc = ast.first_child.t
         @test sc.args == ["page", "anchor"]
-        @test sc.kwargs == Pair{String,String}[]
+        @test sc.kwargs == Pair{String, String}[]
     end
 
     @testset "named args" begin
@@ -165,7 +165,7 @@
     # --- Handlers ---
 
     @testset "parse-time handler inline" begin
-        handlers = Dict{String,Function}(
+        handlers = Dict{String, Function}(
             "greeting" => (name, args, kwargs, ctx) -> CommonMark.text("expanded"),
         )
         p = create_parser(ShortcodeRule(handlers = handlers))
@@ -177,7 +177,7 @@
 
     @testset "handler with context" begin
         seen_source = Ref("")
-        handlers = Dict{String,Function}(
+        handlers = Dict{String, Function}(
             "check" => (name, args, kwargs, ctx) -> begin
                 seen_source[] = ctx.source
                 CommonMark.text("ok")
@@ -189,12 +189,12 @@
     end
 
     @testset "handler for block shortcode" begin
-        handlers = Dict{String,Function}(
+        handlers = Dict{String, Function}(
             "replaced" =>
                 (name, args, kwargs, ctx) -> CommonMark.Node(
-                    CommonMark.Paragraph,
-                    CommonMark.text("replaced content"),
-                ),
+                CommonMark.Paragraph,
+                CommonMark.text("replaced content"),
+            ),
         )
         p = create_parser(ShortcodeRule(handlers = handlers))
         ast = p("{{< replaced >}}")
@@ -204,7 +204,7 @@
     end
 
     @testset "unknown shortcode with handlers" begin
-        handlers = Dict{String,Function}(
+        handlers = Dict{String, Function}(
             "known" => (name, args, kwargs, ctx) -> CommonMark.text("yes"),
         )
         p = create_parser(ShortcodeRule(handlers = handlers))
@@ -215,15 +215,15 @@
     end
 
     @testset "handler returning container with children" begin
-        handlers = Dict{String,Function}(
+        handlers = Dict{String, Function}(
             "multi" =>
                 (name, args, kwargs, ctx) -> begin
-                    CommonMark.Node(
-                        CommonMark.Paragraph,
-                        CommonMark.text("child1 "),
-                        CommonMark.text("child2"),
-                    )
-                end,
+                CommonMark.Node(
+                    CommonMark.Paragraph,
+                    CommonMark.text("child1 "),
+                    CommonMark.text("child2"),
+                )
+            end,
         )
         p = create_parser(ShortcodeRule(handlers = handlers))
         ast = p("{{< multi >}}")
@@ -233,12 +233,12 @@
     end
 
     @testset "handler receiving kwargs" begin
-        handlers = Dict{String,Function}(
+        handlers = Dict{String, Function}(
             "link" =>
                 (name, args, kwargs, ctx) -> begin
-                    href = last(first(p for p in kwargs if first(p) == "href"))
-                    CommonMark.text(href)
-                end,
+                href = last(first(p for p in kwargs if first(p) == "href"))
+                CommonMark.text(href)
+            end,
         )
         p = create_parser(ShortcodeRule(handlers = handlers))
         ast = p("{{< link href=\"https://example.com\" >}}")
@@ -281,11 +281,11 @@
     @testset "Markdown roundtrip" begin
         p = create_parser(ShortcodeRule())
         for input in [
-            "Text {{< sc arg >}} end.",
-            "{{< pagebreak >}}",
-            "A {{< ref page >}} and {{< icon star >}}.",
-            "x {{< video src=\"url\" width=100 >}} y",
-        ]
+                "Text {{< sc arg >}} end.",
+                "{{< pagebreak >}}",
+                "A {{< ref page >}} and {{< icon star >}}.",
+                "x {{< video src=\"url\" width=100 >}} y",
+            ]
             ast = p(input)
             md1 = markdown(ast)
             md2 = markdown(p(md1))
@@ -309,12 +309,12 @@
 
     @testset "write-time transform" begin
         function my_transform(
-            ::MIME"text/html",
-            sc::CommonMark.Shortcode,
-            node,
-            entering,
-            writer,
-        )
+                ::MIME"text/html",
+                sc::CommonMark.Shortcode,
+                node,
+                entering,
+                writer,
+            )
             if sc.name == "hr"
                 n = CommonMark.Node(CommonMark.HtmlInline())
                 n.literal = "<hr>"

--- a/test/extensions/smartlinks.jl
+++ b/test/extensions/smartlinks.jl
@@ -9,12 +9,12 @@
     # Only transform on entering - the writer will use the modified destination
     # Children are visited via the original AST structure
     function transform(
-        ::MIME"text/html",
-        link::CommonMark.Link,
-        node::CommonMark.Node,
-        entering,
-        writer,
-    )
+            ::MIME"text/html",
+            link::CommonMark.Link,
+            node::CommonMark.Node,
+            entering,
+            writer,
+        )
         if entering
             name, _ = splitext(link.destination)
             dest = join([get(writer.env, "root", ""), "$name.html"], "/")
@@ -28,7 +28,7 @@
         (node, entering)
 
     p = create_parser()
-    env = Dict{String,Any}("root" => "/root")
+    env = Dict{String, Any}("root" => "/root")
 
     # Smart link transformation
     ast = p("[link](url.md)")

--- a/test/extensions/strikethrough.jl
+++ b/test/extensions/strikethrough.jl
@@ -15,9 +15,9 @@
     @test html(p("~~**bold**~~")) == "<p><del><strong>bold</strong></del></p>\n"
     @test html(p("~~*italic*~~")) == "<p><del><em>italic</em></del></p>\n"
     @test html(p("*~~italic strikethrough~~*")) ==
-          "<p><em><del>italic strikethrough</del></em></p>\n"
+        "<p><em><del>italic strikethrough</del></em></p>\n"
     @test html(p("**~~bold strikethrough~~**")) ==
-          "<p><strong><del>bold strikethrough</del></strong></p>\n"
+        "<p><strong><del>bold strikethrough</del></strong></p>\n"
 
     # Single tilde - not strikethrough
     @test html(p("~word~")) == "<p>~word~</p>\n"
@@ -42,7 +42,7 @@
 
     # Multiple in paragraph
     @test html(p("~~first~~ and ~~second~~")) ==
-          "<p><del>first</del> and <del>second</del></p>\n"
+        "<p><del>first</del> and <del>second</del></p>\n"
 
     # Three tildes at start of line is a fenced code block, not inline strikethrough
     # Test inline three tildes with surrounding text instead

--- a/test/extensions/subscript.jl
+++ b/test/extensions/subscript.jl
@@ -30,14 +30,14 @@
 
     # Multiple in paragraph
     @test html(p("~first~ and ~second~")) ==
-          "<p><sub>first</sub> and <sub>second</sub></p>\n"
+        "<p><sub>first</sub> and <sub>second</sub></p>\n"
 
     # Combined with strikethrough (if both enabled)
     p2 = create_parser([SubscriptRule(), StrikethroughRule()])
     @test html(p2("~sub~ and ~~strike~~")) ==
-          "<p><sub>sub</sub> and <del>strike</del></p>\n"
+        "<p><sub>sub</sub> and <del>strike</del></p>\n"
     @test html(p2("~~struck ~sub~ text~~")) ==
-          "<p><del>struck <sub>sub</sub> text</del></p>\n"
+        "<p><del>struck <sub>sub</sub> text</del></p>\n"
 
     # Permissive flanking allows punctuation after opener
     @test html(p("x~-1~")) == "<p>x<sub>-1</sub></p>\n"

--- a/test/extensions/superscript.jl
+++ b/test/extensions/superscript.jl
@@ -12,7 +12,7 @@
     @test html(p("^**bold**^")) == "<p><sup><strong>bold</strong></sup></p>\n"
     @test html(p("^*italic*^")) == "<p><sup><em>italic</em></sup></p>\n"
     @test html(p("*^italic superscript^*")) ==
-          "<p><em><sup>italic superscript</sup></em></p>\n"
+        "<p><em><sup>italic superscript</sup></em></p>\n"
 
     # Unclosed superscript
     @test html(p("^unclosed")) == "<p>^unclosed</p>\n"
@@ -31,7 +31,7 @@
 
     # Multiple in paragraph
     @test html(p("^first^ and ^second^")) ==
-          "<p><sup>first</sup> and <sup>second</sup></p>\n"
+        "<p><sup>first</sup> and <sup>second</sup></p>\n"
 
     # Combined with subscript
     p2 = create_parser([SubscriptRule(), SuperscriptRule()])

--- a/test/extensions/tables.jl
+++ b/test/extensions/tables.jl
@@ -9,23 +9,23 @@
 
     # Basic table
     text = """
-           | 1 | 10 | 100 |
-           | - | --:|:---:|
-           | x | y  | z   |
-           """
+    | 1 | 10 | 100 |
+    | - | --:|:---:|
+    | x | y  | z   |
+    """
     ast = p(text)
     test_table("basic", ast, "tables")
 
     # Roundtrip test
     @test markdown(p(markdown(ast))) ==
-          "| 1 | 10 | 100 |\n|:- | --:|:---:|\n| x | y  | z   |\n"
+        "| 1 | 10 | 100 |\n|:- | --:|:---:|\n| x | y  | z   |\n"
 
     # Mis-aligned table pipes
     text = """
-           |1|10|100|
-           | - | --:|:---:|
-           |x|y|z|
-           """
+    |1|10|100|
+    | - | --:|:---:|
+    |x|y|z|
+    """
     ast = p(text)
     test_table("misaligned", ast, "tables")
 
@@ -33,86 +33,86 @@
     p = create_parser([TableRule(), AttributeRule()])
 
     text = """
-           {#id}
-           | 1 | 10 | 100 |
-           | - | --:|:---:|
-           | x | y  | z   |
-           """
+    {#id}
+    | 1 | 10 | 100 |
+    | - | --:|:---:|
+    | x | y  | z   |
+    """
     ast = p(text)
     test_table("with_id", ast, "tables")
 
     # Internal pipes
     text = """
-           |1|10|`|`|
-           | -:| - |:-:|
-           |*|*|![|](url)|
-           |1|2|3|4|
-           """
+    |1|10|`|`|
+    | -:| - |:-:|
+    |*|*|![|](url)|
+    |1|2|3|4|
+    """
     ast = p(text)
     test_table("internal_pipes", ast, "tables")
 
     # Empty columns
     text = """
-           |||
-           |-|-|
-           |||
-           """
+    |||
+    |-|-|
+    |||
+    """
     ast = p(text)
     test_table("empty_columns", ast, "tables")
 
     # Table with header
     text = """
-           # Header
+    # Header
 
-           | table |
-           | ----- |
-           | content |
-           """
+    | table |
+    | ----- |
+    | content |
+    """
     ast = p(text)
     test_table("with_header", ast, "tables")
 
     # Messy tables
     text = """
-           # Messy tables
+    # Messy tables
 
-           | table
-           | :-: |
-           | *|*
-           """
+    | table
+    | :-: |
+    | *|*
+    """
     ast = p(text)
     test_table("messy", ast, "tables")
 
     # Tables with lots of whitespace
     text = """
-           # whitespace (#38)
+    # whitespace (#38)
 
-           | 1         | 2         | 3       |       4 |
-           |   :--:    |   :--     |   ---   |   -:    |
-           | one       | two       |   three |   four  |
-           """
+    | 1         | 2         | 3       |       4 |
+    |   :--:    |   :--     |   ---   |   -:    |
+    | one       | two       |   three |   four  |
+    """
     ast = p(text)
     test_table("whitespace", ast, "tables")
 
     # Unicode content
     text = """
-           | Tables   |      Are      |  Cool |
-           |----------|-------------|------|
-           | col 3 is | right-aligned δεδομέ |   1 |
-           """
+    | Tables   |      Are      |  Cool |
+    |----------|-------------|------|
+    | col 3 is | right-aligned δεδομέ |   1 |
+    """
     ast = p(text)
     test_table("unicode", ast, "tables")
 
     # Consecutive tables separated by blank line
     p = create_parser(TableRule())
     text = """
-           | A | B |
-           |:--|--:|
-           | 1 | 2 |
+    | A | B |
+    |:--|--:|
+    | 1 | 2 |
 
-           | X | Y | Z |
-           |---|---|---|
-           | a | b | c |
-           """
+    | X | Y | Z |
+    |---|---|---|
+    | a | b | c |
+    """
     ast = p(text)
     # Should produce two separate tables
     tables = [n for (n, entering) in ast if entering && n.t isa CommonMark.Table]

--- a/test/extensions/tasklist.jl
+++ b/test/extensions/tasklist.jl
@@ -6,27 +6,27 @@
 
     # Basic unchecked task
     @test html(p("- [ ] unchecked")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> unchecked</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> unchecked</li>\n</ul>\n"
 
     # Basic checked task
     @test html(p("- [x] checked")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled checked> checked</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled checked> checked</li>\n</ul>\n"
 
     # Uppercase X also works
     @test html(p("- [X] also checked")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled checked> also checked</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled checked> also checked</li>\n</ul>\n"
 
     # Multiple tasks
     @test html(p("- [ ] first\n- [x] second\n- [ ] third")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> first</li>\n<li><input type=\"checkbox\" disabled checked> second</li>\n<li><input type=\"checkbox\" disabled> third</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> first</li>\n<li><input type=\"checkbox\" disabled checked> second</li>\n<li><input type=\"checkbox\" disabled> third</li>\n</ul>\n"
 
     # Mixed with regular items (no checkbox pattern)
     @test html(p("- regular item\n- [ ] task item")) ==
-          "<ul>\n<li>regular item</li>\n<li><input type=\"checkbox\" disabled> task item</li>\n</ul>\n"
+        "<ul>\n<li>regular item</li>\n<li><input type=\"checkbox\" disabled> task item</li>\n</ul>\n"
 
     # Ordered list with tasks
     @test html(p("1. [ ] first task\n2. [x] second task")) ==
-          "<ol>\n<li><input type=\"checkbox\" disabled> first task</li>\n<li><input type=\"checkbox\" disabled checked> second task</li>\n</ol>\n"
+        "<ol>\n<li><input type=\"checkbox\" disabled> first task</li>\n<li><input type=\"checkbox\" disabled checked> second task</li>\n</ol>\n"
 
     # Without extension, checkbox pattern is literal text
     p_no_ext = create_parser()
@@ -34,11 +34,11 @@
 
     # Task with inline formatting
     @test html(p("- [ ] **bold** task")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> <strong>bold</strong> task</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> <strong>bold</strong> task</li>\n</ul>\n"
 
     # No space after checkbox is also valid
     @test html(p("- [ ]no space")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> no space</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> no space</li>\n</ul>\n"
 
     # Terminal rendering
     @test term(p("- [ ] unchecked")) == "  ☐ unchecked\n"
@@ -46,7 +46,7 @@
 
     # Markdown roundtrip preserves checkbox
     @test markdown(p("- [ ] unchecked\n- [x] checked")) ==
-          "- [ ] unchecked\n- [x] checked\n"
+        "- [ ] unchecked\n- [x] checked\n"
 
     # Edge cases
 
@@ -58,23 +58,23 @@
 
     # Nested list with task
     @test html(p("- parent\n  - [ ] child task")) ==
-          "<ul>\n<li>parent\n<ul>\n<li><input type=\"checkbox\" disabled> child task</li>\n</ul>\n</li>\n</ul>\n"
+        "<ul>\n<li>parent\n<ul>\n<li><input type=\"checkbox\" disabled> child task</li>\n</ul>\n</li>\n</ul>\n"
 
     # Different bullet characters
     @test html(p("+ [ ] plus")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> plus</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> plus</li>\n</ul>\n"
     @test html(p("* [ ] star")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> star</li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> star</li>\n</ul>\n"
 
     # Task in blockquote
     @test html(p("> - [ ] quoted task")) ==
-          "<blockquote>\n<ul>\n<li><input type=\"checkbox\" disabled> quoted task</li>\n</ul>\n</blockquote>\n"
+        "<blockquote>\n<ul>\n<li><input type=\"checkbox\" disabled> quoted task</li>\n</ul>\n</blockquote>\n"
 
     # Task with link
     @test html(p("- [ ] [link](url)")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> <a href=\"url\">link</a></li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> <a href=\"url\">link</a></li>\n</ul>\n"
 
     # Task with code
     @test html(p("- [ ] `code`")) ==
-          "<ul>\n<li><input type=\"checkbox\" disabled> <code>code</code></li>\n</ul>\n"
+        "<ul>\n<li><input type=\"checkbox\" disabled> <code>code</code></li>\n</ul>\n"
 end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -26,5 +26,5 @@
 
     # Also keep the specific markdown output test for backward compatibility
     @test markdown(ast) ==
-          replace(read(joinpath(@__DIR__, "integration_output.md"), String), "\r" => "")
+        replace(read(joinpath(@__DIR__, "integration_output.md"), String), "\r" => "")
 end

--- a/test/normalize_uri.jl
+++ b/test/normalize_uri.jl
@@ -4,7 +4,7 @@
 
     # RFC 3986 unreserved characters must not be percent-encoded
     @test CommonMark.normalize_uri("https://example.com/~user") ==
-          "https://example.com/~user"
+        "https://example.com/~user"
     @test CommonMark.normalize_uri("hello!world") == "hello!world"
 
     # RFC 3986 reserved characters used as delimiters pass through

--- a/test/readers/markdownast.jl
+++ b/test/readers/markdownast.jl
@@ -152,11 +152,13 @@
         @testset "extensions" begin
             @testset "table" begin
                 p = CommonMark.enable!(CommonMark.Parser(), CommonMark.TableRule())
-                cm = p("""
-                | A | B |
-                |:--|--:|
-                | 1 | 2 |
-                """)
+                cm = p(
+                    """
+                    | A | B |
+                    |:--|--:|
+                    | 1 | 2 |
+                    """
+                )
                 mast = MarkdownAST.Node(cm)
                 table = first(mast.children)
                 @test table.element isa MarkdownAST.Table
@@ -165,10 +167,12 @@
 
             @testset "admonition" begin
                 p = CommonMark.enable!(CommonMark.Parser(), CommonMark.AdmonitionRule())
-                cm = p("""
-                !!! note "Title"
-                    Content
-                """)
+                cm = p(
+                    """
+                    !!! note "Title"
+                        Content
+                    """
+                )
                 mast = MarkdownAST.Node(cm)
                 adm = first(mast.children)
                 @test adm.element isa MarkdownAST.Admonition
@@ -199,11 +203,13 @@
 
             @testset "footnotes" begin
                 p = CommonMark.enable!(CommonMark.Parser(), CommonMark.FootnoteRule())
-                cm = p("""
-                Text[^1].
+                cm = p(
+                    """
+                    Text[^1].
 
-                [^1]: Footnote content.
-                """)
+                    [^1]: Footnote content.
+                    """
+                )
                 mast = MarkdownAST.Node(cm)
                 children = collect(mast.children)
                 @test any(n -> n.element isa MarkdownAST.FootnoteDefinition, children)
@@ -492,24 +498,26 @@
 
         @testset "complex document round-trip" begin
             p = CommonMark.enable!(CommonMark.Parser(), CommonMark.TableRule())
-            original = p("""
-            # Title
+            original = p(
+                """
+                # Title
 
-            Some text with **bold**.
+                Some text with **bold**.
 
-            - item 1
-            - item 2
+                - item 1
+                - item 2
 
-            | A | B |
-            |---|---|
-            | 1 | 2 |
+                | A | B |
+                |---|---|
+                | 1 | 2 |
 
-            > Quote
+                > Quote
 
-            ```julia
-            code()
-            ```
-            """)
+                ```julia
+                code()
+                ```
+                """
+            )
             mast = MarkdownAST.Node(original)
             roundtrip = CommonMark.Node(mast)
 

--- a/test/readers/stdlib.jl
+++ b/test/readers/stdlib.jl
@@ -18,7 +18,7 @@
             md = Markdown.parse("Hello **bold** and *italic*")
             ast = CommonMark.Node(md)
             @test CommonMark.html(ast) ==
-                  "<p>Hello <strong>bold</strong> and <em>italic</em></p>\n"
+                "<p>Hello <strong>bold</strong> and <em>italic</em></p>\n"
         end
 
         @testset "code block" begin
@@ -107,11 +107,13 @@
 
     @testset "extensions" begin
         @testset "table" begin
-            md = Markdown.parse("""
-            | A | B | C |
-            |:--|:-:|--:|
-            | 1 | 2 | 3 |
-            """)
+            md = Markdown.parse(
+                """
+                | A | B | C |
+                |:--|:-:|--:|
+                | 1 | 2 | 3 |
+                """
+            )
             ast = CommonMark.Node(md)
             out = CommonMark.html(ast)
             @test occursin("<table>", out)
@@ -123,10 +125,12 @@
         end
 
         @testset "admonition" begin
-            md = Markdown.parse("""
-            !!! note "Title"
-                Content here
-            """)
+            md = Markdown.parse(
+                """
+                !!! note "Title"
+                    Content here
+                """
+            )
             ast = CommonMark.Node(md)
             out = CommonMark.html(ast)
             @test occursin("admonition note", out)
@@ -141,11 +145,13 @@
         end
 
         @testset "footnotes" begin
-            md = Markdown.parse("""
-            Text[^1].
+            md = Markdown.parse(
+                """
+                Text[^1].
 
-            [^1]: Footnote content.
-            """)
+                [^1]: Footnote content.
+                """
+            )
             ast = CommonMark.Node(md)
             out = CommonMark.html(ast)
             @test occursin("footnote", out)
@@ -164,10 +170,12 @@
 
     @testset "nested MD" begin
         # Nested MD with multiple blocks
-        inner = Markdown.MD([
-            Markdown.Paragraph(["Inner para 1"]),
-            Markdown.Paragraph(["Inner para 2"]),
-        ])
+        inner = Markdown.MD(
+            [
+                Markdown.Paragraph(["Inner para 1"]),
+                Markdown.Paragraph(["Inner para 2"]),
+            ]
+        )
         inner.meta[:inner_key] = "inner_value"
         inner.meta[:shared] = "inner_shared"
 
@@ -190,27 +198,29 @@
     end
 
     @testset "complex document" begin
-        md = Markdown.parse("""
-        # Document Title
+        md = Markdown.parse(
+            """
+            # Document Title
 
-        Some introductory text with **bold** and *italic*.
+            Some introductory text with **bold** and *italic*.
 
-        ## Section 1
+            ## Section 1
 
-        - Item one
-        - Item two with `code`
-        - Item three with [link](https://example.com)
+            - Item one
+            - Item two with `code`
+            - Item three with [link](https://example.com)
 
-        > A blockquote
+            > A blockquote
 
-        ```julia
-        println("Hello")
-        ```
+            ```julia
+            println("Hello")
+            ```
 
-        ---
+            ---
 
-        Final paragraph.
-        """)
+            Final paragraph.
+            """
+        )
         ast = CommonMark.Node(md)
         out = CommonMark.html(ast)
 

--- a/test/sourcepos.jl
+++ b/test/sourcepos.jl
@@ -2,11 +2,11 @@
     using CommonMark
     using Test
     macro_ast_multiline = @__LINE__() + 2,
-    cm"""
-    # Header
+        cm"""
+        # Header
 
-    > quote
-    """
+        > quote
+        """
     out = html(macro_ast_multiline[2]; sourcepos = true)
     @test occursin("data-sourcepos=\"$(macro_ast_multiline[1])", out)
 

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,18 +1,20 @@
 @testitem "extra_spec_tests" tags = [:spec, :core] begin
     using CommonMark
     using Test
-    cases = [(
-        """
-        <textarea>
+    cases = [
+        (
+            """
+            <textarea>
 
-        *foo*
+            *foo*
 
-        _bar_
+            _bar_
 
-        </textarea>
-        """,
-        "<textarea>\n\n*foo*\n\n_bar_\n\n</textarea>\n",
-    )]
+            </textarea>
+            """,
+            "<textarea>\n\n*foo*\n\n_bar_\n\n</textarea>\n",
+        ),
+    ]
     p = Parser()
     for (m, h) in cases
         @test html(p(m)) == h

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -11,14 +11,14 @@
 
     # Multi-format reference testing helper with explicit directory
     function test_all_formats(
-        test_dir::String,
-        base_name::String,
-        ast,
-        reference_dir::String;
-        formats = [:html, :latex, :markdown, :term, :typst],
-        env = nothing,
-        transform = nothing,
-    )
+            test_dir::String,
+            base_name::String,
+            ast,
+            reference_dir::String;
+            formats = [:html, :latex, :markdown, :term, :typst],
+            env = nothing,
+            transform = nothing,
+        )
         format_specs = Dict(
             :html => (html, "html.txt"),
             :latex => (latex, "tex"),
@@ -35,7 +35,7 @@
                 isnothing(env) ? func(ast) : func(ast, env)
             else
                 isnothing(env) ? func(ast; transform = transform) :
-                func(ast, env; transform = transform)
+                    func(ast, env; transform = transform)
             end
             @test_reference filename ReferenceTests.Text(output)
         end
@@ -49,12 +49,12 @@
 
     # Single-format reference testing helper with explicit directory
     function _test_single_format(
-        test_dir::String,
-        filename::String,
-        text::String,
-        parser,
-        format_func,
-    )
+            test_dir::String,
+            filename::String,
+            text::String,
+            parser,
+            format_func,
+        )
         ast = parser(text)
         output = format_func(ast)
         full_path = joinpath(test_dir, filename)
@@ -63,13 +63,13 @@
 
     # Reference test with custom processing
     function test_format_with_processor(
-        test_dir::String,
-        filename::String,
-        text::String,
-        parser,
-        format_func,
-        processor,
-    )
+            test_dir::String,
+            filename::String,
+            text::String,
+            parser,
+            format_func,
+            processor,
+        )
         ast = parser(text)
         output = format_func(ast)
         processed = processor(output)

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -113,20 +113,20 @@
                 CommonMark.literal(
                     writer,
                     """<!DOCTYPE html>
-<html>
-<head>
-<title>$title</title>
-<meta name="author" content="$author">
-</head>
-<body>
-""",
+                    <html>
+                    <head>
+                    <title>$title</title>
+                    <meta name="author" content="$author">
+                    </head>
+                    <body>
+                    """,
                 )
             else
                 CommonMark.literal(
                     writer,
                     """</body>
-</html>
-""",
+                    </html>
+                    """,
                 )
             end
             (node, entering)
@@ -136,7 +136,7 @@
 
         p = Parser()
         ast = p("# Welcome\n\nContent here.")
-        env = Dict{String,Any}("title" => "My Document", "author" => "Jane Doe")
+        env = Dict{String, Any}("title" => "My Document", "author" => "Jane Doe")
 
         result = html(ast, env; transform = xform)
         @test occursin("<title>My Document</title>", result)
@@ -197,7 +197,7 @@
 
         p = Parser()
         ast = p("[link](page)")
-        env = Dict{String,Any}("base_url" => "https://example.com/")
+        env = Dict{String, Any}("base_url" => "https://example.com/")
 
         result = html(ast, env; transform = xform)
         @test occursin("href=\"https://example.com/page\"", result)


### PR DESCRIPTION
Replace JuliaFormatter with Runic. Runic is zero-config and opinionated,
so the `.format/` tooling and empty `.JuliaFormatter.toml` are gone.

The `justfile` now exposes `fmt` and `fmt-check`. CI installs Runic into a
shared `@runic` environment via a small shell shim and runs `just fmt-check`
against the tree. The whole codebase is reformatted to match Runic in the
same change.