### PR TITLE
refactor: code-quality pass across parser, writers, extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Inline parsers for link, image, reference link, table, and attribute syntax now raise a descriptive error when their trigger character is missing, instead of advancing the parser inside an `@assert` that could be disabled and silently corrupt output [#158]
+
 ### Fixed
 
 - Fix `ReferenceLinkRule` crashing with `StringIndexError` on reference definitions whose label contains multibyte characters [#154]
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Typst writer producing inline code whose backticks merged with the delimiters or were misread as a language tag (e.g. `` `code` ``) [#154]
 - Fix `TableRule` rendering padding cells of a short row with `align="left"` instead of the column's declared alignment [#156]
 - Fix `GridTableRule` ignoring colspan in body rows and dropping the character sitting on a column boundary; a body row that omits an internal `|`, or sits above a separator that merges columns, now spans those columns with its content intact [#157]
+- Surface front matter parse errors through `frontmatter(ast)` under the `_error` key instead of silently discarding them [#158]
 
 ## [v1.0.2] - 2026-05-29
 
@@ -497,3 +502,4 @@ Initial release.
 [#154]: https://github.com/MichaelHatherly/CommonMark.jl/issues/154
 [#156]: https://github.com/MichaelHatherly/CommonMark.jl/issues/156
 [#157]: https://github.com/MichaelHatherly/CommonMark.jl/issues/157
+[#158]: https://github.com/MichaelHatherly/CommonMark.jl/issues/158

--- a/src/extensions/attributes.jl
+++ b/src/extensions/attributes.jl
@@ -69,7 +69,8 @@ function try_parse_attributes(parser::AbstractParser)
         # Consume leading spaces.
         read(parser, Char)
     end
-    @assert read(parser, Char) === '{'
+    c = read(parser, Char)
+    c === '{' || error("expected '{' opening attributes, got $(repr(c))")
     valid = false
     dict = Dict{String, Any}()
     key = ""

--- a/src/extensions/citations.jl
+++ b/src/extensions/citations.jl
@@ -48,35 +48,37 @@ end
 
 is_bracket(n::Node, c) = n.literal == c && n.t isa Text
 
+function mark_citation_brackets!(cite::Node, openers::Set{Node}, closers::Set{Node})
+    opener = closer = cite
+    while !isnull(opener.prv)
+        opener = opener.prv
+        opener in openers && return
+        opener.t isa Citation && break
+        if is_bracket(opener, "[")
+            opener.t = CitationBracket()
+            push!(openers, opener)
+            break
+        end
+    end
+    while !isnull(closer.nxt)
+        closer = closer.nxt
+        closer in closers && return
+        closer.t isa Citation && break
+        if is_bracket(closer, "]")
+            closer.t = CitationBracket()
+            push!(closers, closer)
+            break
+        end
+    end
+    return
+end
+
 inline_modifier(rule::CitationRule) = Rule(1) do parser, block
     openers = Set{Node}()
     closers = Set{Node}()
     while !isempty(rule.cites)
         cite = pop!(rule.cites)
-        if cite.t.brackets
-            opener = closer = cite
-            while !isnull(opener.prv)
-                opener = opener.prv
-                opener in openers && @goto SKIP
-                opener.t isa Citation && break
-                if is_bracket(opener, "[")
-                    opener.t = CitationBracket()
-                    push!(openers, opener)
-                    break
-                end
-            end
-            while !isnull(closer.nxt)
-                closer = closer.nxt
-                closer in closers && @goto SKIP
-                closer.t isa Citation && break
-                if is_bracket(closer, "]")
-                    closer.t = CitationBracket()
-                    push!(closers, closer)
-                    break
-                end
-            end
-            @label SKIP
-        end
+        cite.t.brackets && mark_citation_brackets!(cite, openers, closers)
     end
 end
 

--- a/src/extensions/citations.jl
+++ b/src/extensions/citations.jl
@@ -91,7 +91,7 @@ block_modifier(::CitationRule) = Rule(10) do parser, b
     return nothing
 end
 
-# Writers. TODO: implement real CSL for citation styling.
+# Writers. Styling is fixed to author-year; .csl style files are not parsed.
 
 # Citations inside a `Link` would emit nested `<a>` (HTML) or nested
 # `\href`/`\hyperlink` (LaTeX). HTML5 §4.5.1 forbids the former and browsers

--- a/src/extensions/frontmatter.jl
+++ b/src/extensions/frontmatter.jl
@@ -87,7 +87,7 @@ block_modifier(f::FrontMatterRule) = Rule(0.5) do parser, node
         try
             merge!(node.t.data, λ(node.literal))
         catch err
-            node.literal = string(err)
+            node.t.data["_error"] = string(err)
         end
     end
     return nothing

--- a/src/extensions/referencelinks.jl
+++ b/src/extensions/referencelinks.jl
@@ -147,7 +147,8 @@ end
 # Inline rule - intercepts reference links before standard LinkRule
 
 function parse_reference_close_bracket(parser::InlineParser, block::Node)
-    @assert read(parser, Char) === ']'
+    c = read(parser, Char)
+    c === ']' || error("expected ']' closing reference link, got $(repr(c))")
     startpos = position(parser)
 
     opener = parser.brackets

--- a/src/extensions/tables.jl
+++ b/src/extensions/tables.jl
@@ -189,7 +189,8 @@ struct TablePipe <: AbstractInline end
 
 inline_rule(rule::TableRule) = Rule(0, "|") do parser, block
     block.t isa TableRow || return false
-    @assert read(parser, Char) == '|'
+    c = read(parser, Char)
+    c === '|' || error("expected '|' table cell separator, got $(repr(c))")
     eof(parser) && return true # Skip last pipe.
     pipe = Node(TablePipe())
     append_child(block, pipe)

--- a/src/extensions/tables.jl
+++ b/src/extensions/tables.jl
@@ -240,7 +240,7 @@ inline_modifier(rule::TableRule) = Rule(100) do parser, block
         end
     end
     if length(cells) < max_cols
-        # Add addtional cells in this row is below number in spec.
+        # Add additional cells if this row is below number in spec.
         extra = (length(cells) + 1):max_cols
         append!(cells, (Node(TableCell(spec[n], isheader, n, 1, 1)) for n in extra))
     end

--- a/src/parsers.jl
+++ b/src/parsers.jl
@@ -11,7 +11,7 @@ mutable struct StringParser <: AbstractParser
 end
 StringParser(s::AbstractString) = StringParser(String(s), 1, ncodeunits(s))
 
-Base.String(p::AbstractParser) = String(p.buf)
+Base.String(p::AbstractParser) = p.buf
 Base.position(p::AbstractParser) = p.pos
 Base.length(p::AbstractParser) = p.len
 Base.eof(p::AbstractParser) = position(p) > length(p)
@@ -19,12 +19,12 @@ Base.seek(p::AbstractParser, pos) = p.pos = pos
 Base.seekstart(p::AbstractParser) = p.pos = 1
 
 Base.peek(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p)]
-Base.peek(p::AbstractParser, ::Type{Char}) = String(p.buf)[position(p)]
+Base.peek(p::AbstractParser, ::Type{Char}) = p.buf[position(p)]
 
 trypeek(p::AbstractParser, ::Type{UInt8}, default = nothing) =
     get(p.buf, position(p), default)
 trypeek(p::AbstractParser, ::Type{Char}, default = nothing) =
-    get(String(p.buf), thisind(p), default)
+    get(p.buf, thisind(p), default)
 
 function Base.read(p::AbstractParser, ::Type{T}) where {T <: Union{Char, UInt8}}
     obj = peek(p, T)
@@ -43,16 +43,16 @@ bytes(p::AbstractParser, from, to) = view(buffer(p), from:to)
 or(value, default) = value
 or(::Nothing, default) = default
 
-prev(p::AbstractParser, ::Type{Char}) = String(p.buf)[prevind(p)]
-next(p::AbstractParser, ::Type{Char}) = String(p.buf)[nextind(p)]
+prev(p::AbstractParser, ::Type{Char}) = p.buf[prevind(p)]
+next(p::AbstractParser, ::Type{Char}) = p.buf[nextind(p)]
 
 prev(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p) - 1]
 next(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p) + 1]
 
 tryprev(p::AbstractParser, ::Type{Char}, default = nothing) =
-    get(String(p.buf), prevind(p), default)
+    get(p.buf, prevind(p), default)
 trynext(p::AbstractParser, ::Type{Char}, default = nothing) =
-    get(String(p.buf), nextind(p), default)
+    get(p.buf, nextind(p), default)
 
 tryprev(p::AbstractParser, ::Type{UInt8}, default = nothing) =
     get(p.buf, position(p) - 1, default)

--- a/src/parsers/blocks/codeblocks.jl
+++ b/src/parsers/blocks/codeblocks.jl
@@ -50,12 +50,6 @@ function continue_(::CodeBlock, parser::Parser, container::Node)
     return 0
 end
 
-# TODO: make more robust and finalize the 'spec'.
-function split_info_line(str)
-    line = rstrip(lstrip(str, '{'), '}')
-    return split(line, ' ')
-end
-
 function finalize(::CodeBlock, parser::Parser, block::Node)
     cb = block.t::CodeBlock
     finalize_literal!(block)

--- a/src/parsers/inlines/emphasis.jl
+++ b/src/parsers/inlines/emphasis.jl
@@ -43,11 +43,11 @@ function scan_delims(parser::InlineParser, c::AbstractChar)
 
     if c in (''', '"')
         numdelims += 1
-        @assert read(parser, Char) === c
+        read(parser, Char)
     else
         while trypeek(parser, Char) === c
             numdelims += 1
-            @assert read(parser, Char) === c
+            read(parser, Char)
         end
     end
     numdelims == 0 && return (0, false, false)

--- a/src/parsers/inlines/escapes.jl
+++ b/src/parsers/inlines/escapes.jl
@@ -1,5 +1,6 @@
 function parse_backslash(parser::InlineParser, block::Node)
-    @assert read(parser, Char) === '\\'
+    c = read(parser, Char)
+    c === '\\' || error("expected '\\\\' backslash escape, got $(repr(c))")
     char = trypeek(parser, Char)
     if char === '\n'
         read(parser, Char)

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -37,7 +37,7 @@ function Node(
     return node
 end
 
-chomp_ws(parser::InlineParser) = (consume(parser, match(reSpnl, parser)); true)
+chomp_ws(parser::InlineParser) = (consume(parser, match(reSpnl, parser)); nothing)
 
 function parse_link_title(parser::InlineParser)
     title = consume(parser, match(reLinkTitle, parser))
@@ -154,12 +154,14 @@ function parse_close_bracket(parser::InlineParser, block::Node)
         read(parser, Char)
         chomp_ws(parser)
         dest = parse_link_destination(parser)
-        if dest !== nothing && chomp_ws(parser)
+        if dest !== nothing
+            chomp_ws(parser)
             # Make sure there's a space before the title.
             if prev(parser, Char) in WHITESPACECHAR
                 title = parse_link_title(parser)
             end
-            if chomp_ws(parser) && trypeek(parser, Char, '\0') === ')'
+            chomp_ws(parser)
+            if trypeek(parser, Char, '\0') === ')'
                 read(parser, Char)
                 matched = true
             end

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -115,7 +115,7 @@ function parse_bang(parser::InlineParser, block::Node)
         @assert read(parser, Char) === '['
         node = text("![")
         append_child(block, node)
-        # Add entry to stack for this openeer.
+        # Add entry to stack for this opener.
         add_bracket!(parser, node, startpos + 1, true)
     else
         append_child(block, text("!"))

--- a/src/parsers/inlines/links.jl
+++ b/src/parsers/inlines/links.jl
@@ -59,18 +59,18 @@ function parse_link_destination(parser::InlineParser)
                 break
             end
             if c == '\\' && trynext(parser, Char) in ESCAPABLE
-                @assert read(parser, Char) === '\\'
+                read(parser, Char)
                 if trypeek(parser, Char) !== nothing
                     read(parser, Char)
                 end
             elseif c == '('
-                @assert read(parser, Char) === '('
+                read(parser, Char)
                 openparens += 1
             elseif c == ')'
                 if openparens < 1
                     break
                 else
-                    @assert read(parser, Char) === ')'
+                    read(parser, Char)
                     openparens -= 1
                 end
             elseif c in WHITESPACECHAR
@@ -100,7 +100,8 @@ end
 
 function parse_open_bracket(parser::InlineParser, block::Node)
     startpos = position(parser)
-    @assert read(parser, Char) === '['
+    c = read(parser, Char)
+    c === '[' || error("expected '[' opening link bracket, got $(repr(c))")
     node = text("[")
     append_child(block, node)
     # Add entry to stack for this opener.
@@ -110,9 +111,10 @@ end
 
 function parse_bang(parser::InlineParser, block::Node)
     startpos = position(parser)
-    @assert read(parser, Char) === '!'
+    c = read(parser, Char)
+    c === '!' || error("expected '!' opening image, got $(repr(c))")
     if trypeek(parser, Char) === '['
-        @assert read(parser, Char) === '['
+        read(parser, Char)
         node = text("![")
         append_child(block, node)
         # Add entry to stack for this opener.
@@ -126,7 +128,8 @@ end
 function parse_close_bracket(parser::InlineParser, block::Node)
     title = nothing
     matched = false
-    @assert read(parser, Char) === ']'
+    c = read(parser, Char)
+    c === ']' || error("expected ']' closing link bracket, got $(repr(c))")
     startpos = position(parser)
     # Get last [ or ![.
     opener = parser.brackets
@@ -148,7 +151,7 @@ function parse_close_bracket(parser::InlineParser, block::Node)
     savepos = position(parser)
     # Inline link?
     if trypeek(parser, Char, '\0') === '('
-        @assert read(parser, Char) === '('
+        read(parser, Char)
         chomp_ws(parser)
         dest = parse_link_destination(parser)
         if dest !== nothing && chomp_ws(parser)
@@ -157,7 +160,7 @@ function parse_close_bracket(parser::InlineParser, block::Node)
                 title = parse_link_title(parser)
             end
             if chomp_ws(parser) && trypeek(parser, Char, '\0') === ')'
-                @assert read(parser, Char) === ')'
+                read(parser, Char)
                 matched = true
             end
         else
@@ -249,7 +252,7 @@ function parse_reference(parser::InlineParser, s::AbstractString, refmap::Dict)
 
     # Colon.
     trypeek(parser, Char) === ':' || (seek(parser, startpos); return 0)
-    @assert read(parser, Char) === ':'
+    read(parser, Char)
 
     # Link URL.
     chomp_ws(parser)

--- a/src/parsers/inlines/text.jl
+++ b/src/parsers/inlines/text.jl
@@ -31,7 +31,8 @@ struct TextRule end
 inline_rule(::TextRule) = Rule(parse_string, 1, "")
 
 function parse_newline(parser::InlineParser, block::Node)
-    @assert read(parser, Char) === '\n'
+    c = read(parser, Char)
+    c === '\n' || error("expected newline, got $(repr(c))")
     lastc = block.last_child
     if !isnull(lastc) && lastc.t isa Text && endswith(lastc.literal, ' ')
         child = Node(endswith(lastc.literal, "  ") ? LineBreak() : SoftBreak())

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -132,6 +132,37 @@ function cr(r::Writer)
 end
 
 """
+Print out all the current segments present in the margin buffer.
+
+Each time a segment gets printed it's count is reduced. When a segment has a
+count of zero it won't be printed and instead spaces equal to it's width are
+printed. For persistent printing a count of -1 should be used.
+"""
+function print_margin(r::Writer)
+    r.enabled || return
+    for seg in r.format.margin
+        if seg.count == 0
+            # Blank space case.
+            print(r.format.buffer, ' '^seg.width)
+        else
+            # The normal case, where .count is reduced after each print.
+            print(r.format.buffer, seg.text)
+            seg.count > 0 && (seg.count -= 1)
+        end
+    end
+    return
+end
+
+function maybe_print_margin(r, node::Node)
+    if isnull(node.first_child)
+        push_margin!(r, "\n")
+        print_margin(r)
+        pop_margin!(r)
+    end
+    return nothing
+end
+
+"""
     default_transform(mime, container, node, entering, writer)
 
 Default transform - passes through node unchanged.

--- a/src/writers/term.jl
+++ b/src/writers/term.jl
@@ -286,37 +286,6 @@ function pop_inline!(r::Writer)
 end
 
 """
-Print out all the current segments present in the margin buffer.
-
-Each time a segment gets printed it's count is reduced. When a segment has a
-count of zero it won't be printed and instead spaces equal to it's width are
-printed. For persistent printing a count of -1 should be used.
-"""
-function print_margin(r::Writer)
-    r.enabled || return
-    for seg in r.format.margin
-        if seg.count == 0
-            # Blank space case.
-            print(r.format.buffer, ' '^seg.width)
-        else
-            # The normal case, where .count is reduced after each print.
-            print(r.format.buffer, seg.text)
-            seg.count > 0 && (seg.count -= 1)
-        end
-    end
-    return
-end
-
-function maybe_print_margin(r, node::Node)
-    if isnull(node.first_child)
-        push_margin!(r, "\n")
-        print_margin(r)
-        pop_margin!(r)
-    end
-    return nothing
-end
-
-"""
 Literal printing of a of `parts`. Behaviour depends on when `.wrap` is active
 at the moment, which is set in `Paragraph` rendering.
 """

--- a/test/extensions/frontmatter.jl
+++ b/test/extensions/frontmatter.jl
@@ -72,4 +72,17 @@
     ast = p(text)
     @test markdown(ast) == "---\nfield: data\n---\n"
     @test markdown(p(markdown(ast))) == markdown(ast)
+
+    # A parse failure must be observable in the frontmatter data, not silently dropped.
+    bad = """
+    ;;;
+    {not valid json
+    ;;;
+    ;;;
+    """
+    ast = p(bad)
+    data = frontmatter(ast)
+    @test haskey(data, "_error")
+    @test data["_error"] isa AbstractString
+    @test !isempty(data["_error"])
 end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -196,3 +196,24 @@ end
     @test decode("&#65;") == "A"
     @test decode("&#x10FFFF;") == "\U10FFFF"
 end
+
+@testitem "inline_handler_preconditions" tags = [:core] begin
+    using CommonMark
+    using Test
+
+    # Dispatch-entry handlers rely on a non-local guarantee: the inline parser
+    # peeks the trigger char before calling the handler. The handler must fail
+    # fast if that precondition is violated, not silently consume the wrong char.
+    inline_at = function (s)
+        p = CommonMark.InlineParser()
+        p.buf = s
+        p.pos = 1
+        p.len = ncodeunits(s)
+        return p
+    end
+    block = CommonMark.Node(CommonMark.Document())
+
+    @test_throws ErrorException CommonMark.parse_backslash(inline_at("x"), block)
+    @test_throws ErrorException CommonMark.parse_newline(inline_at("x"), block)
+    @test_throws ErrorException CommonMark.parse_open_bracket(inline_at("x"), block)
+end


### PR DESCRIPTION
A focused code-quality review of the parser core, writers, and extensions. Deletes dead code, makes a silent failure observable, hardens parser invariants, and trims duplication. No spec-behavior changes; the suite stays green (2444 tests).

- **Front matter parse errors are now observable.** They were written to `node.literal`, which every writer renders to nothing, so failures vanished. Now recorded under `frontmatter(ast)["_error"]`.
- **Parser advance moved out of `@assert`.** `@assert read(parser, Char) === c` advanced the parser inside an assertion, which the docs say may be disabled. Dispatch-entry inline handlers (link/image/reference brackets, `!`, newline, backslash, table `|`, attribute `{`) now fail fast with `error()` on a violated trigger char; sites proven by the preceding line use a bare `read`.
- **`chomp_ws` no longer masquerades as a condition.** It consumes optional whitespace and always returned `true`, so the `&&` chains read as conditions but only sequenced a side effect. Pulled out into statements.
- **Smaller cleanups:** move format-agnostic `print_margin`/`maybe_print_margin` from `term.jl` to `writers.jl`; replace `@goto`/`@label` in `citations.jl` with an early-return helper; delete unused `split_info_line`; drop redundant `String(p.buf)` wrapping; fix comment typos.