### PR TITLE
Check benchmark CI runner variance (no-op)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,6 +2,8 @@
 
 Continuous benchmarking tracks performance over time. Results stored in `benchmark-results` branch, visualized via GitHub Pages.
 
+PR comparisons measure the branch fresh and diff it against a baseline JSON stored from the last master run. The two measurements come from different GitHub runners, so absolute deltas carry cross-runner variance. Treat a flagged change as a signal to measure locally on one machine, not as proof.
+
 ## Running locally
 
 ```bash


### PR DESCRIPTION
Control experiment. This branch changes a doc file only, so the compiled package is byte-identical to `c2520db`, the commit the stored benchmark baseline was measured at.

If the benchmark job still flags `parse/*` and `notebook/*` regressions and a `latex/spec_md` improvement against the baseline, those deltas come from comparing two measurements on different GitHub runners, not from any code change.

Local same-hardware A/B (aarch64 native and x86_64 under Rosetta) shows baseline and the `mh/code-quality-review` branch within ~1% on `parse/complex`. This PR confirms the CI signal source.

Close after reading the benchmark result.