### PR TITLE
fix(writers): raw-html fence and terminal wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `TableRule` rendering padding cells of a short row with `align="left"` instead of the column's declared alignment [#156]
 - Fix `GridTableRule` ignoring colspan in body rows and dropping the character sitting on a column boundary; a body row that omits an internal `|`, or sits above a separator that merges columns, now spans those columns with its content intact [#157]
 - Surface front matter parse errors through `frontmatter(ast)` under the `_error` key instead of silently discarding them [#158]
+- Fix Markdown writer producing an unparseable fence for raw inline HTML (`` `…`{=html} ``) whose content starts or ends with a backtick or contains a run of two or more backticks [#161]
+- Fix terminal writer emitting a leading blank line when wrapping a word longer than the line, and looping on a character wider than the available width [#161]
 
 ## [v1.0.2] - 2026-05-29
 
@@ -503,3 +505,4 @@ Initial release.
 [#156]: https://github.com/MichaelHatherly/CommonMark.jl/issues/156
 [#157]: https://github.com/MichaelHatherly/CommonMark.jl/issues/157
 [#158]: https://github.com/MichaelHatherly/CommonMark.jl/issues/158
+[#161]: https://github.com/MichaelHatherly/CommonMark.jl/issues/161

--- a/src/parsers.jl
+++ b/src/parsers.jl
@@ -18,16 +18,13 @@ Base.eof(p::AbstractParser) = position(p) > length(p)
 Base.seek(p::AbstractParser, pos) = p.pos = pos
 Base.seekstart(p::AbstractParser) = p.pos = 1
 
-Base.peek(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p)]
 Base.peek(p::AbstractParser, ::Type{Char}) = p.buf[position(p)]
 
-trypeek(p::AbstractParser, ::Type{UInt8}, default = nothing) =
-    get(p.buf, position(p), default)
 trypeek(p::AbstractParser, ::Type{Char}, default = nothing) =
     get(p.buf, thisind(p), default)
 
-function Base.read(p::AbstractParser, ::Type{T}) where {T <: Union{Char, UInt8}}
-    obj = peek(p, T)
+function Base.read(p::AbstractParser, ::Type{Char})
+    obj = peek(p, Char)
     seek(p, nextind(p))
     return obj
 end
@@ -46,18 +43,10 @@ or(::Nothing, default) = default
 prev(p::AbstractParser, ::Type{Char}) = p.buf[prevind(p)]
 next(p::AbstractParser, ::Type{Char}) = p.buf[nextind(p)]
 
-prev(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p) - 1]
-next(p::AbstractParser, ::Type{UInt8}) = p.buf[position(p) + 1]
-
 tryprev(p::AbstractParser, ::Type{Char}, default = nothing) =
     get(p.buf, prevind(p), default)
 trynext(p::AbstractParser, ::Type{Char}, default = nothing) =
     get(p.buf, nextind(p), default)
-
-tryprev(p::AbstractParser, ::Type{UInt8}, default = nothing) =
-    get(p.buf, position(p) - 1, default)
-trynext(p::AbstractParser, ::Type{UInt8}, default = nothing) =
-    get(p.buf, position(p) + 1, default)
 
 Base.prevind(p::AbstractParser) = prevind(String(p), position(p))
 Base.thisind(p::AbstractParser) = thisind(String(p), position(p))

--- a/src/parsers/blocks/blockquotes.jl
+++ b/src/parsers/blocks/blockquotes.jl
@@ -9,7 +9,7 @@ function continue_(::BlockQuote, parser::Parser, container::Node)
     if !parser.indented && peek_nonspace(parser) == '>'
         advance_next_nonspace(parser)
         advance_offset(parser, 1, false)
-        if is_space_or_tab(trypeek(parser, UInt8))
+        if is_space_or_tab(trypeek(parser, Char))
             advance_offset(parser, 1, true)
         end
     else
@@ -29,7 +29,7 @@ function block_quote(parser::Parser, container::Node)
         advance_next_nonspace(parser)
         advance_offset(parser, 1, false)
         # optional following space
-        if is_space_or_tab(trypeek(parser, UInt8))
+        if is_space_or_tab(trypeek(parser, Char))
             advance_offset(parser, 1, true)
         end
         close_unmatched_blocks(parser)

--- a/src/parsers/blocks/codeblocks.jl
+++ b/src/parsers/blocks/codeblocks.jl
@@ -32,7 +32,7 @@ function continue_(::CodeBlock, parser::Parser, container::Node)
         else
             # skip optional spaces of fence offset
             i = cb.fence_offset
-            while i > 0 && is_space_or_tab(trypeek(parser, UInt8))
+            while i > 0 && is_space_or_tab(trypeek(parser, Char))
                 advance_offset(parser, 1, true)
                 i -= 1
             end

--- a/src/parsers/blocks/lists.jl
+++ b/src/parsers/blocks/lists.jl
@@ -77,7 +77,7 @@ function parse_list_marker(parser::Parser, container::Node)
     spaces_start_offset = parser.pos
     while true
         advance_offset(parser, 1, true)
-        nextc = trypeek(parser, UInt8, '\0')
+        nextc = trypeek(parser, Char, '\0')
         if parser.column - spaces_start_col < 5 && is_space_or_tab(nextc)
             nothing
         else
@@ -90,7 +90,7 @@ function parse_list_marker(parser::Parser, container::Node)
         data.padding = length(m.match) + 1
         parser.column = spaces_start_col
         parser.pos = spaces_start_offset
-        if is_space_or_tab(trypeek(parser, UInt8, '\0'))
+        if is_space_or_tab(trypeek(parser, Char, '\0'))
             advance_offset(parser, 1, true)
         end
     else

--- a/src/writers/markdown.jl
+++ b/src/writers/markdown.jl
@@ -107,34 +107,28 @@ function write_markdown(::LineBreak, w, node, ent)
     return print_margin(w)
 end
 
-function write_markdown(::Code, w, node, ent)
-    # Find longest consecutive backtick run in content
-    num = foldl(eachmatch(r"`+", node.literal); init = 0) do a, b
+# Emit `content` wrapped in a backtick span, with a trailing `suffix` after the
+# closing delimiter. The delimiter is the next odd count longer than the longest
+# backtick run in `content` (even counts collide with math syntax), and content
+# that starts or ends with a backtick is space-padded so it can't merge with the
+# delimiter.
+function backtick_span(w, content, suffix = "")
+    num = foldl(eachmatch(r"`+", content); init = 0) do a, b
         max(a, length(b.match))
     end
-    # Use next odd number > num (avoid even counts which are math syntax)
     backticks = num + (isodd(num) ? 2 : 1)
-    content = node.literal
-    # Add space padding if content starts/ends with backtick (avoid merging with delimiter)
     pad = !isempty(content) && (startswith(content, '`') || endswith(content, '`'))
     literal(w, "`"^backticks)
     pad && literal(w, " ")
     literal(w, content)
     pad && literal(w, " ")
-    return literal(w, "`"^backticks)
+    return literal(w, "`"^backticks, suffix)
 end
 
+write_markdown(::Code, w, node, ent) = backtick_span(w, node.literal)
+
 function write_markdown(t::HtmlInline, w, node, ent)
-    return if t.raw
-        num = foldl(eachmatch(r"`+", node.literal); init = 0) do a, b
-            max(a, length(b.match))
-        end
-        literal(w, '`'^(num == 1 ? 2 : 1))
-        literal(w, node.literal)
-        literal(w, '`'^(num == 1 ? 2 : 1), "{=html}")
-    else
-        literal(w, node.literal)
-    end
+    return t.raw ? backtick_span(w, node.literal, "{=html}") : literal(w, node.literal)
 end
 
 function write_markdown(link::Link, w, node, ent)

--- a/src/writers/term.jl
+++ b/src/writers/term.jl
@@ -323,16 +323,19 @@ function _index_at_column(s::AbstractString, col::Integer)
     return lastindex(s)
 end
 
-function print_literal_part(r::Writer{Term}, lit::AbstractString, rec = 0)
+function print_literal_part(r::Writer{Term}, lit::AbstractString)
     width = Base.Unicode.textwidth(lit)
     space = (available_columns(r) - r.format.wrap) + ispunct(get(lit, 1, '\0'))
-    return if width <= space
+    return if isempty(lit) || width <= space
         print(r.format.buffer, lit)
         r.format.wrap += width
     else
         break_idx = _index_at_column(lit, space)
         index = findprev(c -> c in " -–—", lit, break_idx)
-        index = index === nothing ? (rec > 0 ? break_idx : 0) : index
+        # No break point in range: push the whole word to a fresh line. When
+        # already at the line start a fresh line cannot help, so hard-break,
+        # keeping at least the first character so the tail always shrinks.
+        index = something(index, r.format.wrap == 0 ? max(break_idx, firstindex(lit)) : 0)
         head = SubString(lit, 1, index)
         tail = SubString(lit, nextind(lit, index))
 
@@ -341,7 +344,7 @@ function print_literal_part(r::Writer{Term}, lit::AbstractString, rec = 0)
         print_margin(r)
         r.format.wrap = 0
 
-        print_literal_part(r, lstrip(tail), rec + 1)
+        print_literal_part(r, lstrip(tail))
     end
 end
 print_literal_part(r::Writer{Term}, c::Crayon) = print(r.format.buffer, c)

--- a/test/writers/markdown.jl
+++ b/test/writers/markdown.jl
@@ -133,4 +133,21 @@
     @test markdown(p("````` ```ticks``` `````")) == "````` ```ticks``` `````\n"
     # Mixed single and double → triple (max run is 2), no edge backticks
     @test markdown(p("``` `` and ` ```")) == "``` `` and ` ```\n"
+
+    # Raw inline HTML round-trip: fence must exceed the longest internal backtick run
+    rawp = create_parser(RawContentRule())
+    for content in ["plain", "a`b", "a``b", "a```b", "`x`", "x`", "`x", "``", "`{=html}`"]
+        doc = CommonMark.Node(CommonMark.Document())
+        para = CommonMark.Node(CommonMark.Paragraph())
+        raw = CommonMark.Node(CommonMark.HtmlInline(raw = true))
+        raw.literal = content
+        CommonMark.append_child(para, raw)
+        CommonMark.append_child(doc, para)
+        out = markdown(doc)
+        lit = nothing
+        for (n, ent) in rawp(out)
+            n.t isa CommonMark.HtmlInline && ent && (lit = n.literal)
+        end
+        @test lit == content
+    end
 end

--- a/test/writers/term.jl
+++ b/test/writers/term.jl
@@ -85,4 +85,26 @@ end
     output = String(take!(buf))
     lines = filter(!isempty, split(output, '\n'))
     @test length(lines) == 1
+
+    # Test D: an over-long unbreakable word hard-breaks without a leading blank line.
+    buf = IOBuffer()
+    ast = Parser()("x"^40)
+    show(IOContext(buf, :displaysize => (24, 14)), MIME"text/plain"(), ast)
+    output = replace(String(take!(buf)), r"\e\[[0-9;]*m" => "")
+    lines = split(rstrip(output, '\n'), '\n')
+    @test !isempty(strip(first(lines)))
+end
+
+@testitem "term_wrapping_progress" tags = [:writers, :term] begin
+    using CommonMark
+
+    # A character wider than the available column must still make progress
+    # (one grapheme per line) rather than recurse forever. Calls the internal
+    # wrapper directly to bypass the `available_columns < 5` guard.
+    fmt = CommonMark.Term()
+    fmt.wrap = 0
+    w = CommonMark.Writer(fmt, IOContext(IOBuffer(), :displaysize => (24, 1)))
+    CommonMark.print_literal_part(w, "你好世界")
+    out = String(take!(fmt.buffer))
+    @test all(c -> occursin(c, out), "你好世界")
 end


### PR DESCRIPTION
The Markdown writer's raw inline HTML path (`` `…`{=html} ``) chose a fence shorter than the longest backtick run in the content and skipped the space-padding the `Code` writer already applies, so content with leading or trailing backticks, or a run of two or more, re-parsed as something else. Both writers now share a `backtick_span` helper.

The terminal writer printed a leading blank line when an over-long word sat at the start of a line, and the recursion that wraps long words relied on the distant `available_columns < 5` guard to terminate. `print_literal_part` now keeps at least the first character on each hard break, so it makes progress on any width.

The `UInt8`-tagged parser accessors returned a `Char` identical to the `Char` variants, and the dead `prev`/`next` ones indexed by raw byte offset. The five live callers move to the `Char` accessors and the unused methods are removed.